### PR TITLE
feat(python): generate typed event bindings from SEP-48 contract specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ print(assembled_tx.result())
 # assembled_tx.sign_and_submit()
 ```
 
+If the contract declares events in its SEP-48 spec (supported since Protocol
+23), the generated Python bindings also include a typed class per event, a
+`topic_filter()` builder for `getEvents`, and a `parse_event` dispatcher that
+accepts `xdr.ContractEvent`, RPC `EventInfo`, or raw `(topics, data)` values.
+
 #### Java
 ```java
 public class Example extends ContractClient {

--- a/stellar_contract_bindings/python.py
+++ b/stellar_contract_bindings/python.py
@@ -1,6 +1,10 @@
+import builtins
 import keyword
 import os
-from typing import List
+import re
+import unicodedata
+from typing import Callable, List, Tuple
+
 import black
 
 import click
@@ -10,6 +14,110 @@ from stellar_sdk import xdr
 
 from stellar_contract_bindings import __version__ as stellar_contract_bindings_version
 from stellar_contract_bindings.utils import get_specs_by_contract_id
+
+UdtNameResolver = Callable[[str], str]
+
+_GENERATED_MODULE_NAMES = {
+    "Address",
+    "AssembledTransaction",
+    "AssembledTransactionAsync",
+    "Client",
+    "ClientAsync",
+    "ContractClient",
+    "ContractClientAsync",
+    "Dict",
+    "EllipsisType",
+    "Enum",
+    "EventInfo",
+    "IntEnum",
+    "Keypair",
+    "List",
+    "MuxedAccount",
+    "NULL_ACCOUNT",
+    "Optional",
+    "Sequence",
+    "Tuple",
+    "Union",
+    "UnparsedEventError",
+    "_EVENTS",
+    "_coerce_event_scval",
+    "_event_topics_and_data",
+    "_from_error_scval",
+    "_logger",
+    "_static_topic_matches",
+    "logging",
+    "parse_event",
+    "scval",
+    "xdr",
+}
+_RESERVED_MODULE_NAMES = frozenset(dir(builtins)) | _GENERATED_MODULE_NAMES
+
+
+def _udt_spec_name(spec: xdr.SCSpecEntry) -> str | None:
+    if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0:
+        return spec.udt_struct_v0.name.decode()
+    if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0:
+        return spec.udt_enum_v0.name.decode()
+    if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0:
+        return spec.udt_error_enum_v0.name.decode()
+    if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0:
+        return spec.udt_union_v0.name.decode()
+    return None
+
+
+def resolve_udt_names(specs: List[xdr.SCSpecEntry]) -> dict[str, str]:
+    """Map each UDT spec name to a unique Python class name.
+
+    Spec names may be module-qualified (``pkg::mod::Type``), which is not a
+    valid identifier. The bare last segment is preferred, so bindings for the
+    common unqualified case keep the name the contract uses. The full path,
+    flattened with underscores, is used only when several modules claim the
+    same bare name; a numeric suffix breaks any remaining tie, including with
+    the names the generator itself emits.
+    """
+    spec_names = list(
+        dict.fromkeys(
+            name for spec in specs if (name := _udt_spec_name(spec)) is not None
+        )
+    )
+    union_names = {
+        spec.udt_union_v0.name.decode()
+        for spec in specs
+        if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0
+    }
+
+    claimants: dict[str, int] = {}
+    for spec_name in spec_names:
+        bare = _default_udt_name(spec_name)
+        claimants[bare] = claimants.get(bare, 0) + 1
+
+    used: set[str] = set(_RESERVED_MODULE_NAMES)
+    resolved: dict[str, str] = {}
+    for spec_name in spec_names:
+        bare = _default_udt_name(spec_name)
+        if claimants[bare] == 1:
+            base = bare
+        else:
+            segments = [segment for segment in spec_name.split("::") if segment]
+            base = python_identifier("_".join(segments) if segments else spec_name)
+        name = base
+        suffix = 2
+        # A union also emits a companion "<name>Kind" enum, so both have to be
+        # free before the name can be claimed.
+        while name in used or (spec_name in union_names and f"{name}Kind" in used):
+            name = f"{base}{suffix}"
+            suffix += 1
+        used.add(name)
+        if spec_name in union_names:
+            used.add(f"{name}Kind")
+        resolved[spec_name] = name
+    return resolved
+
+
+def _udt_reference_resolver(names: dict[str, str]) -> UdtNameResolver:
+    # A spec may reference a UDT it does not declare; fall back to the bare
+    # name so the reference at least renders as a valid identifier.
+    return lambda spec_name: names.get(spec_name) or _default_udt_name(spec_name)
 
 
 def is_tuple_struct(entry: xdr.SCSpecUDTStructV0) -> bool:
@@ -27,7 +135,16 @@ def camel_to_snake(text: str) -> str:
     return result
 
 
-def to_py_type(td: xdr.SCSpecTypeDef, input_type: bool = False):
+def _default_udt_name(spec_name: str) -> str:
+    segments = [segment for segment in spec_name.split("::") if segment]
+    return python_identifier(segments[-1] if segments else spec_name)
+
+
+def to_py_type(
+    td: xdr.SCSpecTypeDef,
+    input_type: bool = False,
+    resolve_udt_name: UdtNameResolver = _default_udt_name,
+):
     t = td.type
     if t == xdr.SCSpecType.SC_SPEC_TYPE_VAL:
         return "xdr.SCVal"
@@ -36,7 +153,7 @@ def to_py_type(td: xdr.SCSpecTypeDef, input_type: bool = False):
     if t == xdr.SCSpecType.SC_SPEC_TYPE_VOID:
         return "None"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_ERROR:
-        raise NotImplementedError("SC_SPEC_TYPE_ERROR is not supported")
+        return "xdr.SCError"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_U32:
         return "int"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_I32:
@@ -63,33 +180,46 @@ def to_py_type(td: xdr.SCSpecTypeDef, input_type: bool = False):
         return "bytes"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_SYMBOL:
         return "str"
-    if t == xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS or t == xdr.SCSpecType.SC_SPEC_TYPE_MUXED_ADDRESS:
+    if (
+        t == xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS
+        or t == xdr.SCSpecType.SC_SPEC_TYPE_MUXED_ADDRESS
+    ):
         return "Union[Address, str]" if input_type else "Address"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_MUXED_ADDRESS:
         raise NotImplementedError("SC_SPEC_TYPE_MUXED_ADDRESS is not supported")
     if t == xdr.SCSpecType.SC_SPEC_TYPE_OPTION:
-        return f"Optional[{to_py_type(td.option.value_type, input_type)}]"
+        return f"Optional[{to_py_type(td.option.value_type, input_type, resolve_udt_name)}]"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_RESULT:
         ok_t = td.result.ok_type
-        return to_py_type(ok_t, input_type)
+        error_t = td.result.error_type
+        return (
+            f"Union[{to_py_type(ok_t, input_type, resolve_udt_name)}, "
+            f"{to_py_type(error_t, input_type, resolve_udt_name)}]"
+        )
     if t == xdr.SCSpecType.SC_SPEC_TYPE_VEC:
-        return f"List[{to_py_type(td.vec.element_type, input_type)}]"
+        return f"List[{to_py_type(td.vec.element_type, input_type, resolve_udt_name)}]"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_MAP:
-        return f"Dict[{to_py_type(td.map.key_type, input_type)}, {to_py_type(td.map.value_type, input_type)}]"
+        return f"Dict[{to_py_type(td.map.key_type, input_type, resolve_udt_name)}, {to_py_type(td.map.value_type, input_type, resolve_udt_name)}]"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_TUPLE:
         if len(td.tuple.value_types) == 0:
             # () equivalent to None in Python
             return "None"
-        types = [to_py_type(t, input_type) for t in td.tuple.value_types]
+        types = [
+            to_py_type(t, input_type, resolve_udt_name) for t in td.tuple.value_types
+        ]
         return f"Tuple[{', '.join(types)}]"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_BYTES_N:
         return f"bytes"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_UDT:
-        return td.udt.name.decode()
+        return resolve_udt_name(td.udt.name.decode())
     raise ValueError(f"Unsupported SCValType: {t}")
 
 
-def to_scval(td: xdr.SCSpecTypeDef, name: str):
+def to_scval(
+    td: xdr.SCSpecTypeDef,
+    name: str,
+    resolve_udt_name: UdtNameResolver = _default_udt_name,
+):
     t = td.type
     if t == xdr.SCSpecType.SC_SPEC_TYPE_VAL:
         return f"{name}"
@@ -98,7 +228,7 @@ def to_scval(td: xdr.SCSpecTypeDef, name: str):
     if t == xdr.SCSpecType.SC_SPEC_TYPE_VOID:
         return f"scval.to_void()"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_ERROR:
-        raise NotImplementedError("SC_SPEC_TYPE_ERROR is not supported")
+        return f"xdr.SCVal(xdr.SCValType.SCV_ERROR, error={name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_U32:
         return f"scval.to_uint32({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_I32:
@@ -125,21 +255,37 @@ def to_scval(td: xdr.SCSpecTypeDef, name: str):
         return f"scval.to_string({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_SYMBOL:
         return f"scval.to_symbol({name})"
-    if t == xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS or t == xdr.SCSpecType.SC_SPEC_TYPE_MUXED_ADDRESS:
+    if (
+        t == xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS
+        or t == xdr.SCSpecType.SC_SPEC_TYPE_MUXED_ADDRESS
+    ):
         return f"scval.to_address({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_MUXED_ADDRESS:
         raise NotImplementedError("SC_SPEC_TYPE_MUXED_ADDRESS is not supported")
     if t == xdr.SCSpecType.SC_SPEC_TYPE_OPTION:
-        return f"{to_scval(td.option.value_type, name)} if {name} is not None else scval.to_void()"
+        return f"{to_scval(td.option.value_type, name, resolve_udt_name)} if {name} is not None else scval.to_void()"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_RESULT:
-        return NotImplementedError("SC_SPEC_TYPE_RESULT is not supported")
+        error_t = td.result.error_type
+        error_py_type = to_py_type(
+            error_t, input_type=True, resolve_udt_name=resolve_udt_name
+        )
+        error_test = (
+            f"isinstance({name}, xdr.SCError)"
+            if error_t.type == xdr.SCSpecType.SC_SPEC_TYPE_ERROR
+            else f"isinstance({name}, {error_py_type})"
+        )
+        return (
+            f"{to_scval(error_t, name, resolve_udt_name)} if {error_test} "
+            f"else {to_scval(td.result.ok_type, name, resolve_udt_name)}"
+        )
     if t == xdr.SCSpecType.SC_SPEC_TYPE_VEC:
-        return f"scval.to_vec([{to_scval(td.vec.element_type, 'e')} for e in {name}])"
+        return f"scval.to_vec([{to_scval(td.vec.element_type, 'e', resolve_udt_name)} for e in {name}])"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_MAP:
-        return f"scval.to_map({{{to_scval(td.map.key_type, 'k')}: {to_scval(td.map.value_type, 'v')} for k, v in {name}.items()}})"
+        return f"scval.to_map({{{to_scval(td.map.key_type, 'k', resolve_udt_name)}: {to_scval(td.map.value_type, 'v', resolve_udt_name)} for k, v in {name}.items()}})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_TUPLE:
         types = [
-            to_scval(t, f"{name}[{i}]") for i, t in enumerate(td.tuple.value_types)
+            to_scval(t, f"{name}[{i}]", resolve_udt_name)
+            for i, t in enumerate(td.tuple.value_types)
         ]
         return f"scval.to_tuple_struct([{', '.join(types)}])"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_BYTES_N:
@@ -149,16 +295,20 @@ def to_scval(td: xdr.SCSpecTypeDef, name: str):
     raise ValueError(f"Unsupported SCValType: {t}")
 
 
-def from_scval(td: xdr.SCSpecTypeDef, name: str):
+def from_scval(
+    td: xdr.SCSpecTypeDef,
+    name: str,
+    resolve_udt_name: UdtNameResolver = _default_udt_name,
+):
     t = td.type
     if t == xdr.SCSpecType.SC_SPEC_TYPE_VAL:
         return f"{name}"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_BOOL:
         return f"scval.from_bool({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_VOID:
-        return f"scval.from_void()"
+        return f"scval.from_void({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_ERROR:
-        raise NotImplementedError("SC_SPEC_TYPE_ERROR is not supported")
+        return f"_from_error_scval({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_U32:
         return f"scval.from_uint32({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_I32:
@@ -185,34 +335,40 @@ def from_scval(td: xdr.SCSpecTypeDef, name: str):
         return f"scval.from_string({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_SYMBOL:
         return f"scval.from_symbol({name})"
-    if t == xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS or t == xdr.SCSpecType.SC_SPEC_TYPE_MUXED_ADDRESS:
+    if (
+        t == xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS
+        or t == xdr.SCSpecType.SC_SPEC_TYPE_MUXED_ADDRESS
+    ):
         return f"scval.from_address({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_MUXED_ADDRESS:
         raise NotImplementedError("SC_SPEC_TYPE_MUXED_ADDRESS is not supported")
     if t == xdr.SCSpecType.SC_SPEC_TYPE_OPTION:
-        return f"{from_scval(td.option.value_type, name)} if {name}.type != xdr.SCValType.SCV_VOID else scval.from_void({name})"
+        return f"{from_scval(td.option.value_type, name, resolve_udt_name)} if {name}.type != xdr.SCValType.SCV_VOID else scval.from_void({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_RESULT:
         ok_t = td.result.ok_type
-        return f"{from_scval(ok_t, name)}"
-    if t == xdr.SCSpecType.SC_SPEC_TYPE_VEC:
+        error_t = td.result.error_type
         return (
-            f"[{from_scval(td.vec.element_type, 'e')} for e in scval.from_vec({name})]"
+            f"{from_scval(error_t, name, resolve_udt_name)} "
+            f"if {name}.type == xdr.SCValType.SCV_ERROR else "
+            f"{from_scval(ok_t, name, resolve_udt_name)}"
         )
+    if t == xdr.SCSpecType.SC_SPEC_TYPE_VEC:
+        return f"[{from_scval(td.vec.element_type, 'e', resolve_udt_name)} for e in scval.from_vec({name})]"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_MAP:
-        return f"{{{from_scval(td.map.key_type, 'k')}: {from_scval(td.map.value_type, 'v')} for k, v in scval.from_map({name}).items()}}"
+        return f"{{{from_scval(td.map.key_type, 'k', resolve_udt_name)}: {from_scval(td.map.value_type, 'v', resolve_udt_name)} for k, v in scval.from_map({name}).items()}}"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_TUPLE:
         if len(td.tuple.value_types) == 0:
             return "None"
         elements = f"scval.from_tuple_struct({name})"
         types = [
-            from_scval(t, f"{elements}[{i}]")
+            from_scval(t, f"{elements}[{i}]", resolve_udt_name)
             for i, t in enumerate(td.tuple.value_types)
         ]
         return f"({', '.join(types)})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_BYTES_N:
         return f"scval.from_bytes({name})"
     if t == xdr.SCSpecType.SC_SPEC_TYPE_UDT:
-        return f"{td.udt.name.decode()}.from_scval({name})"
+        return f"{resolve_udt_name(td.udt.name.decode())}.from_scval({name})"
     raise NotImplementedError(f"Unsupported SCValType: {t}")
 
 
@@ -220,12 +376,17 @@ def render_info():
     return f"# This file was generated by stellar_contract_bindings v{stellar_contract_bindings_version} and stellar_sdk v{stellar_sdk_version}."
 
 
-def render_imports(client_type: str = "both"):
+def render_imports(client_type: str = "both", has_events: bool = False):
     template = """
 from __future__ import annotations
 
+{%- if has_events %}
+import logging
+from types import EllipsisType
+{%- endif %}
 from enum import IntEnum, Enum
-from typing import Dict, List, Tuple, Optional, Union
+{#- Sequence is only used by the event input types. #}
+from typing import Dict, List, {% if has_events %}Sequence, {% endif %}Tuple, Optional, Union
 
 from stellar_sdk import scval, xdr, Address, MuxedAccount, Keypair
 {%- if client_type == "sync" or client_type == "both" %}
@@ -234,16 +395,31 @@ from stellar_sdk.contract import AssembledTransaction, ContractClient
 {%- if client_type == "async" or client_type == "both" %}
 from stellar_sdk.contract import AssembledTransactionAsync, ContractClientAsync
 {%- endif %}
+{%- if has_events %}
+from stellar_sdk.soroban_rpc import EventInfo
+{%- endif %}
 
 NULL_ACCOUNT = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
 """
-    rendered_code = Template(template).render(client_type=client_type)
+    rendered_code = Template(template).render(
+        client_type=client_type, has_events=has_events
+    )
     return rendered_code
 
 
-def render_enum(entry: xdr.SCSpecUDTEnumV0):
+def render_scval_helpers():
+    return """
+def _from_error_scval(value: xdr.SCVal) -> xdr.SCError:
+    if value.type != xdr.SCValType.SCV_ERROR or value.error is None:
+        raise ValueError(f"expected SCV_ERROR, got {value.type}")
+    return value.error
+"""
+
+
+def render_enum(entry: xdr.SCSpecUDTEnumV0, class_name: str | None = None):
+    class_name = class_name or _default_udt_name(entry.name.decode())
     template = """
-class {{ entry.name.decode() }}(IntEnum):
+class {{ class_name }}(IntEnum):
     {%- if entry.doc %}
     '''{{ entry.doc.decode() }}'''
     {%- endif %}
@@ -258,13 +434,14 @@ class {{ entry.name.decode() }}(IntEnum):
         return cls(scval.from_uint32(val))
 """
 
-    rendered_code = Template(template).render(entry=entry)
+    rendered_code = Template(template).render(entry=entry, class_name=class_name)
     return rendered_code
 
 
-def render_error_enum(entry: xdr.SCSpecUDTErrorEnumV0):
+def render_error_enum(entry: xdr.SCSpecUDTErrorEnumV0, class_name: str | None = None):
+    class_name = class_name or _default_udt_name(entry.name.decode())
     template = """
-class {{ entry.name.decode() }}(IntEnum):
+class {{ class_name }}(IntEnum):
     {%- if entry.doc %}
     '''{{ entry.doc.decode() }}'''
     {%- endif %}
@@ -272,20 +449,34 @@ class {{ entry.name.decode() }}(IntEnum):
     {{ case.name.decode() }} = {{ case.value.uint32 }}
     {%- endfor %}
     def to_scval(self) -> xdr.SCVal:
-        return scval.to_uint32(self.value)
+        return xdr.SCVal(
+            xdr.SCValType.SCV_ERROR,
+            error=xdr.SCError(
+                xdr.SCErrorType.SCE_CONTRACT,
+                contract_code=xdr.Uint32(self.value),
+            ),
+        )
 
     @classmethod
     def from_scval(cls, val: xdr.SCVal):
-        return cls(scval.from_uint32(val))
+        error = _from_error_scval(val)
+        if error.type != xdr.SCErrorType.SCE_CONTRACT or error.contract_code is None:
+            raise ValueError("expected an SCE_CONTRACT error")
+        return cls(error.contract_code.uint32)
     """
 
-    rendered_code = Template(template).render(entry=entry)
+    rendered_code = Template(template).render(entry=entry, class_name=class_name)
     return rendered_code
 
 
-def render_struct(entry: xdr.SCSpecUDTStructV0):
+def render_struct(
+    entry: xdr.SCSpecUDTStructV0,
+    class_name: str | None = None,
+    resolve_udt_name: UdtNameResolver = _default_udt_name,
+):
+    class_name = class_name or _default_udt_name(entry.name.decode())
     template = """
-class {{ entry.name.decode() }}:
+class {{ class_name }}:
     {%- if entry.doc %}
     '''{{ entry.doc.decode() }}'''
     {%- endif %}
@@ -315,7 +506,7 @@ class {{ entry.name.decode() }}:
         )
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, {{ entry.name.decode() }}):
+        if not isinstance(other, {{ class_name }}):
             return NotImplemented
         return {% for field in entry.fields %}self.{{ field.name.decode() }} == other.{{ field.name.decode() }}{% if not loop.last %} and {% endif %}{% endfor %}
 
@@ -325,17 +516,25 @@ class {{ entry.name.decode() }}:
 
     rendered_code = Template(template).render(
         entry=entry,
-        to_py_type=to_py_type,
-        to_scval=to_scval,
-        from_scval=from_scval,
+        class_name=class_name,
+        to_py_type=lambda td, input_type=False: to_py_type(
+            td, input_type, resolve_udt_name
+        ),
+        to_scval=lambda td, name: to_scval(td, name, resolve_udt_name),
+        from_scval=lambda td, name: from_scval(td, name, resolve_udt_name),
         enumerate=enumerate,
     )
     return rendered_code
 
 
-def render_tuple_struct(entry: xdr.SCSpecUDTStructV0):
+def render_tuple_struct(
+    entry: xdr.SCSpecUDTStructV0,
+    class_name: str | None = None,
+    resolve_udt_name: UdtNameResolver = _default_udt_name,
+):
+    class_name = class_name or _default_udt_name(entry.name.decode())
     template = """
-class {{ entry.name.decode() }}:
+class {{ class_name }}:
     {%- if entry.doc %}
     '''{{ entry.doc.decode() }}'''
     {%- endif %}
@@ -353,7 +552,7 @@ class {{ entry.name.decode() }}:
         return cls(values)
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, {{ entry.name.decode() }}):
+        if not isinstance(other, {{ class_name }}):
             return NotImplemented
         return self.value == other.value
 
@@ -362,14 +561,25 @@ class {{ entry.name.decode() }}:
 """
 
     rendered_code = Template(template).render(
-        entry=entry, to_py_type=to_py_type, to_scval=to_scval, from_scval=from_scval
+        entry=entry,
+        class_name=class_name,
+        to_py_type=lambda td, input_type=False: to_py_type(
+            td, input_type, resolve_udt_name
+        ),
+        to_scval=lambda td, name: to_scval(td, name, resolve_udt_name),
+        from_scval=lambda td, name: from_scval(td, name, resolve_udt_name),
     )
     return rendered_code
 
 
-def render_union(entry: xdr.SCSpecUDTUnionV0):
+def render_union(
+    entry: xdr.SCSpecUDTUnionV0,
+    class_name: str | None = None,
+    resolve_udt_name: UdtNameResolver = _default_udt_name,
+):
+    class_name = class_name or _default_udt_name(entry.name.decode())
     kind_enum_template = """
-class {{ entry.name.decode() }}Kind(Enum):
+class {{ class_name }}Kind(Enum):
     {%- for case in entry.cases %}
     {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 %}
     {{ case.void_case.name.decode() }} = '{{ case.void_case.name_r.decode() if case.void_case.name_r else case.void_case.name.decode() }}'
@@ -379,15 +589,17 @@ class {{ entry.name.decode() }}Kind(Enum):
     {%- endfor %}
 """
 
-    kind_enum_rendered_code = Template(kind_enum_template).render(entry=entry, xdr=xdr)
+    kind_enum_rendered_code = Template(kind_enum_template).render(
+        entry=entry, class_name=class_name, xdr=xdr
+    )
 
     template = """
-class {{ entry.name.decode() }}:
+class {{ class_name }}:
     {%- if entry.doc %}
     '''{{ entry.doc.decode() }}'''
     {%- endif %}
     def __init__(self,
-        kind: {{ entry.name.decode() }}Kind,
+        kind: {{ class_name }}Kind,
         {%- for case in entry.cases %}
         {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_TUPLE_V0 %}
         {%- if len(case.tuple_case.type) == 1 %}
@@ -408,10 +620,10 @@ class {{ entry.name.decode() }}:
     def to_scval(self) -> xdr.SCVal:
         {%- for case in entry.cases %}
         {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 %}
-        if self.kind == {{ entry.name.decode() }}Kind.{{ case.void_case.name.decode() }}:
+        if self.kind == {{ class_name }}Kind.{{ case.void_case.name.decode() }}:
             return scval.to_enum(self.kind.name, None)
         {%- else %}
-        if self.kind == {{ entry.name.decode() }}Kind.{{ case.tuple_case.name.decode() }}:
+        if self.kind == {{ class_name }}Kind.{{ case.tuple_case.name.decode() }}:
         {%- if len(case.tuple_case.type) == 1 %}
             assert self.{{ camel_to_snake(case.tuple_case.name.decode()) }} is not None
             return scval.to_enum(self.kind.name, {{ to_scval(case.tuple_case.type[0], 'self.' ~ camel_to_snake(case.tuple_case.name.decode())) }})
@@ -430,14 +642,14 @@ class {{ entry.name.decode() }}:
     @classmethod
     def from_scval(cls, val: xdr.SCVal):
         elements = scval.from_enum(val)
-        kind = {{ entry.name.decode() }}Kind(elements[0])
+        kind = {{ class_name }}Kind(elements[0])
         
         {%- for case in entry.cases %}
         {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 %}
-        if kind == {{ entry.name.decode() }}Kind.{{ case.void_case.name.decode() }}:
+        if kind == {{ class_name }}Kind.{{ case.void_case.name.decode() }}:
             return cls(kind)
         {%- else %}
-        if kind == {{ entry.name.decode() }}Kind.{{ case.tuple_case.name.decode() }}:
+        if kind == {{ class_name }}Kind.{{ case.tuple_case.name.decode() }}:
         {%- if len(case.tuple_case.type) == 1 %}
             assert elements[1] is not None and isinstance(elements[1], xdr.SCVal)
             return cls(kind, {{ camel_to_snake(case.tuple_case.name.decode()) }}={{ from_scval(case.tuple_case.type[0], 'elements[1]') }})
@@ -454,13 +666,13 @@ class {{ entry.name.decode() }}:
         raise ValueError(f"Invalid kind: {kind}")
     
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, {{ entry.name.decode() }}):
+        if not isinstance(other, {{ class_name }}):
             return NotImplemented
         if self.kind != other.kind:
             return False
         {%- for case in entry.cases %}
         {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_TUPLE_V0 %}
-        if self.kind == {{ entry.name.decode() }}Kind.{{ case.tuple_case.name.decode() }}:
+        if self.kind == {{ class_name }}Kind.{{ case.tuple_case.name.decode() }}:
             return self.{{ camel_to_snake(case.tuple_case.name.decode()) }} == other.{{ camel_to_snake(case.tuple_case.name.decode()) }}
         {%- endif %}
         {%- endfor %}
@@ -469,7 +681,7 @@ class {{ entry.name.decode() }}:
     def __hash__(self) -> int:
         {%- for case in entry.cases %}
         {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_TUPLE_V0 %}
-        if self.kind == {{ entry.name.decode() }}Kind.{{ case.tuple_case.name.decode() }}:
+        if self.kind == {{ class_name }}Kind.{{ case.tuple_case.name.decode() }}:
             return hash((self.kind, self.{{ camel_to_snake(case.tuple_case.name.decode()) }}))
         {%- endif %}
         {%- endfor %}
@@ -477,9 +689,12 @@ class {{ entry.name.decode() }}:
 """
     union_rendered_code = Template(template).render(
         entry=entry,
-        to_py_type=to_py_type,
-        to_scval=to_scval,
-        from_scval=from_scval,
+        class_name=class_name,
+        to_py_type=lambda td, input_type=False: to_py_type(
+            td, input_type, resolve_udt_name
+        ),
+        to_scval=lambda td, name: to_scval(td, name, resolve_udt_name),
+        from_scval=lambda td, name: from_scval(td, name, resolve_udt_name),
         xdr=xdr,
         len=len,
         camel_to_snake=camel_to_snake,
@@ -488,7 +703,522 @@ class {{ entry.name.decode() }}:
     return kind_enum_rendered_code + "\n" + union_rendered_code
 
 
-def render_client(entries: List[xdr.SCSpecFunctionV0], client_type: str):
+def python_identifier(name: str) -> str:
+    """Return a valid Python identifier while preserving as much text as possible."""
+    name = unicodedata.normalize("NFKC", name)
+    candidate = "".join(char if ("a" + char).isidentifier() else "_" for char in name)
+    if not candidate:
+        candidate = "_"
+    if not (candidate[0] == "_" or candidate[0].isidentifier()):
+        candidate = "_" + candidate
+    if keyword.iskeyword(candidate) or (
+        candidate.startswith("__") and candidate.endswith("__")
+    ):
+        candidate += "_"
+    return candidate
+
+
+def event_class_name(name: str) -> str:
+    sanitized = python_identifier(name)
+    parts = [part for part in re.split(r"_+", sanitized) if part]
+    pascal = "".join(part[:1].upper() + part[1:] for part in parts) or "Event"
+    pascal = python_identifier(pascal)
+    return pascal if pascal.endswith("Event") else pascal + "Event"
+
+
+def render_event_helpers():
+    return '''
+_logger = logging.getLogger(__name__)
+
+
+def _coerce_event_scval(value: Union[xdr.SCVal, str, bytes]) -> xdr.SCVal:
+    if isinstance(value, xdr.SCVal):
+        return value
+    if isinstance(value, bytes):
+        return xdr.SCVal.from_xdr_bytes(value)
+    return xdr.SCVal.from_xdr(value)
+
+
+def _event_topics_and_data(
+    event: Union[
+        xdr.ContractEvent,
+        EventInfo,
+        Tuple[
+            Sequence[Union[xdr.SCVal, str, bytes]],
+            Union[xdr.SCVal, str, bytes],
+        ],
+    ],
+) -> Tuple[List[xdr.SCVal], xdr.SCVal]:
+    """Normalize transaction-meta, RPC, or raw-XDR event input."""
+    if isinstance(event, xdr.ContractEvent):
+        if event.body.v0 is None:
+            raise ValueError("contract event has no v0 body")
+        return list(event.body.v0.topics), event.body.v0.data
+    if isinstance(event, EventInfo):
+        return (
+            [_coerce_event_scval(topic) for topic in event.topic],
+            _coerce_event_scval(event.value),
+        )
+    if isinstance(event, tuple) and len(event) == 2:
+        topics, data = event
+        return (
+            [_coerce_event_scval(topic) for topic in topics],
+            _coerce_event_scval(data),
+        )
+    raise TypeError(
+        "event must be ContractEvent, EventInfo, or a (topics, data) tuple"
+    )
+
+
+def _static_topic_matches(topic: xdr.SCVal, expected: str) -> bool:
+    """SEP-48: when matching, parsers should tolerate static topics being of
+    the SCVal type SCV_SYMBOL or SCV_STRING."""
+    if topic.type == xdr.SCValType.SCV_SYMBOL:
+        return scval.from_symbol(topic) == expected
+    if topic.type == xdr.SCValType.SCV_STRING:
+        return scval.from_string(topic) == expected.encode()
+    return False
+
+
+class UnparsedEventError(ValueError):
+    """The event's topics matched one or more declared events, but none of the
+    candidate classes could parse it.
+
+    This usually means the on-chain event format has drifted from the contract
+    spec these bindings were generated from (e.g. a contract upgrade or a
+    protocol change). ``failures`` holds each candidate class and the exception
+    its ``parse()`` raised.
+    """
+
+    def __init__(self, message: str, failures: List[Tuple[type, Exception]]):
+        super().__init__(message)
+        self.failures = failures
+'''
+
+
+def declared_topic_count(entry: xdr.SCSpecEventV0) -> int:
+    return len(entry.prefix_topics) + sum(
+        1
+        for p in entry.params
+        if p.location
+        == xdr.SCSpecEventParamLocationV0.SC_SPEC_EVENT_PARAM_LOCATION_TOPIC_LIST
+    )
+
+
+def _declared_type_names(
+    specs: List[xdr.SCSpecEntry], udt_names: dict[str, str] | None = None
+) -> set[str]:
+    if udt_names is None:
+        udt_names = resolve_udt_names(specs)
+    used = set(udt_names.values())
+    for spec in specs:
+        if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0:
+            used.add(udt_names[spec.udt_union_v0.name.decode()] + "Kind")
+    return used
+
+
+def resolve_event_names(
+    specs: List[xdr.SCSpecEntry],
+    event_specs: List[xdr.SCSpecEventV0],
+    udt_names: dict[str, str] | None = None,
+) -> Tuple[List[str], str]:
+    """Assign a unique module-level class name to each event entry.
+
+    Collisions — with UDT type names (including the generated ``<Union>Kind``
+    enums) or between events whose names normalize identically (``foo`` and
+    ``foo_event``) — are resolved by appending underscores. The generated
+    event-union alias is allocated from the same namespace, so a UDT or event
+    named ``Event`` cannot overwrite another generated symbol.
+    """
+    used = _declared_type_names(specs, udt_names) | set(_RESERVED_MODULE_NAMES)
+    union_name = "Event"
+    while union_name in used:
+        union_name += "_"
+    used.add(union_name)
+
+    class_names = []
+    for event_spec in event_specs:
+        name = event_class_name(event_spec.name.sc_symbol.decode())
+        while name in used:
+            name += "_"
+        used.add(name)
+        class_names.append(name)
+    return class_names, union_name
+
+
+def event_diagnostics(
+    event_specs: List[xdr.SCSpecEventV0], class_names: List[str]
+) -> List[str]:
+    """Describe every event whose class name is not the obvious one.
+
+    Two declarations can share an event name, and a name can collide with a
+    generated type, so the class name alone does not always identify which
+    declaration it came from. Each message is ready to print.
+    """
+    declaration_counts: dict[str, int] = {}
+    for event_spec in event_specs:
+        raw_name = event_spec.name.sc_symbol.decode()
+        declaration_counts[raw_name] = declaration_counts.get(raw_name, 0) + 1
+
+    occurrences: dict[str, int] = {}
+    messages = []
+    for event_spec, class_name in zip(event_specs, class_names):
+        raw_name = event_spec.name.sc_symbol.decode()
+        occurrence = occurrences.get(raw_name, 0) + 1
+        occurrences[raw_name] = occurrence
+        declarations = declaration_counts[raw_name]
+        reasons = []
+        if declarations > 1:
+            reasons.append(
+                f"declaration {occurrence} of {declarations} with this event name"
+            )
+        if class_name != event_class_name(raw_name):
+            reasons.append("renamed to avoid a generated-name collision")
+        if reasons:
+            messages.append(
+                f"Event binding note: {raw_name!r} -> {class_name} "
+                f"({'; '.join(reasons)})"
+            )
+    return messages
+
+
+def resolve_event_param_names(entry: xdr.SCSpecEventV0) -> List[str]:
+    """Allocate valid, unique constructor/attribute names for an event."""
+    used = {"self", "cls"}
+    names = []
+    for param in entry.params:
+        name = python_identifier(param.name.decode())
+        while unicodedata.normalize("NFKC", name) in used:
+            name += "_"
+        used.add(unicodedata.normalize("NFKC", name))
+        names.append(name)
+    return names
+
+
+def _event_doc(entry: xdr.SCSpecEventV0, param_names: List[str]) -> str:
+    lines = []
+    if entry.doc:
+        lines.append(entry.doc.decode())
+
+    documented_params = [
+        (param, param_name)
+        for param, param_name in zip(entry.params, param_names)
+        if param.doc
+    ]
+    if documented_params:
+        if lines:
+            lines.append("")
+        lines.append("Attributes:")
+        for param, param_name in documented_params:
+            wire_name = param.name.decode()
+            name_note = f" (wire name {wire_name!r})" if param_name != wire_name else ""
+            lines.append(f"    {param_name}{name_note}: {param.doc.decode()}")
+    return "\n".join(lines)
+
+
+def render_event(
+    entry: xdr.SCSpecEventV0,
+    class_name: str,
+    resolve_udt_name: UdtNameResolver = _default_udt_name,
+):
+    prefix_symbols = [s.sc_symbol.decode() for s in entry.prefix_topics]
+    data_format = entry.data_format
+    data_params = [
+        param
+        for param in entry.params
+        if param.location
+        == xdr.SCSpecEventParamLocationV0.SC_SPEC_EVENT_PARAM_LOCATION_DATA
+    ]
+    if (
+        data_format == xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE
+        and len(data_params) > 1
+    ):
+        raise ValueError(
+            "SINGLE_VALUE events may declare at most one data parameter; "
+            f"{entry.name.sc_symbol.decode()!r} declares {len(data_params)}"
+        )
+
+    param_names = resolve_event_param_names(entry)
+    params = []
+    topic_params = []
+    required_data_keys: List[str] = []
+    topic_index = len(prefix_symbols)
+    data_index = 0
+    for p, py_name in zip(entry.params, param_names):
+        chain_name = p.name.decode()
+        py_type = to_py_type(p.type, resolve_udt_name=resolve_udt_name)
+        if (
+            p.location
+            == xdr.SCSpecEventParamLocationV0.SC_SPEC_EVENT_PARAM_LOCATION_TOPIC_LIST
+        ):
+            parse_expr = from_scval(p.type, f"topics[{topic_index}]", resolve_udt_name)
+            topic_index += 1
+            topic_params.append(
+                {
+                    "py_name": py_name,
+                    "input_type": to_py_type(
+                        p.type, input_type=True, resolve_udt_name=resolve_udt_name
+                    ),
+                    "filter_expr": to_scval(p.type, py_name, resolve_udt_name),
+                }
+            )
+        elif (
+            data_format
+            == xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE
+        ):
+            parse_expr = from_scval(p.type, "data", resolve_udt_name)
+        elif data_format == xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_VEC:
+            parse_expr = from_scval(p.type, f"_data[{data_index}]", resolve_udt_name)
+            data_index += 1
+        elif data_format == xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_MAP:
+            # SEP-48 requires the map to carry every declared parameter, but an
+            # emitter may omit one declared as an option: SEP-41 permits SAC
+            # ``to_muxed_id`` to be absent when there is no muxed ID, and the
+            # SAC spec indeed declares it as an option. Absent optionals become
+            # None; a missing required entry is rejected in parse() instead of
+            # silently yielding a half-populated event.
+            value_expr = f"_data[{chain_name!r}]"
+            if p.type.type == xdr.SCSpecType.SC_SPEC_TYPE_OPTION:
+                parse_expr = (
+                    f"({from_scval(p.type, value_expr, resolve_udt_name)}) "
+                    f"if {chain_name!r} in _data else None"
+                )
+            else:
+                parse_expr = from_scval(p.type, value_expr, resolve_udt_name)
+                required_data_keys.append(chain_name)
+        else:
+            raise ValueError(f"Unsupported event data format: {data_format}")
+        params.append(
+            {
+                "py_name": py_name,
+                "py_type": py_type,
+                "parse_expr": parse_expr,
+            }
+        )
+    has_vec_data = data_format == (
+        xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_VEC
+    )
+    has_map_data = data_format == (
+        xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_MAP
+    )
+    validate_void_data = (
+        data_format == xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE
+        and not data_params
+    )
+    event_doc = _event_doc(entry, param_names)
+
+    template = """
+class {{ class_name }}:
+    {%- if event_doc %}
+    __doc__ = {{ event_doc }}
+    {%- endif %}
+    EVENT_NAME = {{ event_name }}
+
+    {%- for p in params %}
+    {{ p.py_name }}: {{ p.py_type }}
+    {%- endfor %}
+
+    def __init__(self{% for p in params %}, {{ p.py_name }}: {{ p.py_type }}{% endfor %}):
+        {%- for p in params %}
+        self.{{ p.py_name }} = {{ p.py_name }}
+        {%- else %}
+        pass
+        {%- endfor %}
+
+    @classmethod
+    def topic_filter(
+        cls{% if topic_params %},
+        *,
+        {%- for p in topic_params %}
+        {{ p.py_name }}: Union[{{ p.input_type }}, EllipsisType] = ...,
+        {%- endfor %}
+        {%- endif %}
+    ) -> List[str]:
+        '''Build one topics row for ``SorobanServer.get_events``.
+
+        Omitted topic parameters are emitted as ``"*"`` wildcards. The row ends
+        with ``"**"`` so that, like ``matches()``, it also selects events
+        carrying extra trailing topics beyond the SEP-48 declaration. Without
+        it the RPC matches on the exact topic count and such events are
+        silently skipped. ``"**"`` requires stellar-rpc v23.0.0 or newer, which
+        is also the release that introduced SEP-48 event specs; it is excluded
+        from the four-segment filter limit.
+        '''
+        return [
+            {%- for s in prefix_symbols %}
+            scval.to_symbol({{ s }}).to_xdr(),
+            {%- endfor %}
+            {%- for p in topic_params %}
+            "*" if {{ p.py_name }} is ... else ({{ p.filter_expr }}).to_xdr(),
+            {%- endfor %}
+            "**",
+        ]
+
+    @classmethod
+    def matches(cls, event: {{ event_input_type }}) -> bool:
+        '''Returns True if the event topics match this event's shape.
+
+        Extra trailing topics beyond the declared parameters are ignored:
+        on-chain events may append topics that are not part of the SEP-48
+        declaration (e.g. Stellar Asset Contract events append the SEP-11
+        asset string).
+        '''
+        try:
+            topics, _ = _event_topics_and_data(event)
+        except Exception:
+            return False
+        if len(topics) < {{ total_topics }}:
+            return False
+        {%- for s in prefix_symbols %}
+        if not _static_topic_matches(topics[{{ loop.index0 }}], {{ s }}):
+            return False
+        {%- endfor %}
+        return True
+
+    @classmethod
+    def parse(cls, event: {{ event_input_type }}) -> {{ class_name }}:
+        '''Parse the event into a {{ class_name }}.
+
+        :raises ValueError: If the event does not match this event's shape.
+        '''
+        # Decode once and hand matches() the normalized pair; matches() would
+        # otherwise decode the raw event a second time.
+        topics, data = _event_topics_and_data(event)
+        if not cls.matches((topics, data)):
+            raise ValueError('event does not match {{ class_name }}')
+        {%- if validate_void_data %}
+        scval.from_void(data)
+        {%- endif %}
+        {%- if has_vec_data %}
+        _data = scval.from_vec(data)
+        if len(_data) < {{ data_param_count }}:
+            raise ValueError("event data vector has fewer values than declared")
+        {%- endif %}
+        {%- if has_map_data %}
+        _data = scval.from_struct(data)
+        {%- if required_data_keys %}
+        _missing = [_k for _k in [{{ required_data_keys | join(', ') }}] if _k not in _data]
+        if _missing:
+            raise ValueError(f"event data map is missing required entries: {_missing}")
+        {%- endif %}
+        {%- endif %}
+        return cls(
+            {%- for p in params %}
+            {{ p.py_name }}={{ p.parse_expr }},
+            {%- endfor %}
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, {{ class_name }}):
+            return NotImplemented
+        return {% for p in params %}self.{{ p.py_name }} == other.{{ p.py_name }}{% if not loop.last %} and {% endif %}{% else %}True{% endfor %}
+
+    def __hash__(self) -> int:
+        return hash(({% for p in params %}self.{{ p.py_name }}, {% endfor %}))
+
+    def __repr__(self):
+        return f"<{{ class_name }} [{% for p in params %}{{ p.py_name }}={self.{{ p.py_name }}}{% if not loop.last %}, {% endif %}{% endfor %}]>"
+"""
+    rendered_code = Template(template).render(
+        class_name=class_name,
+        event_doc=repr(event_doc) if event_doc else None,
+        event_name=repr(entry.name.sc_symbol.decode()),
+        prefix_symbols=[repr(symbol) for symbol in prefix_symbols],
+        total_topics=declared_topic_count(entry),
+        params=params,
+        topic_params=topic_params,
+        event_input_type=(
+            "Union[xdr.ContractEvent, EventInfo, "
+            "Tuple[Sequence[Union[xdr.SCVal, str, bytes]], "
+            "Union[xdr.SCVal, str, bytes]]]"
+        ),
+        has_vec_data=has_vec_data,
+        has_map_data=has_map_data,
+        required_data_keys=[repr(key) for key in required_data_keys],
+        validate_void_data=validate_void_data,
+        data_param_count=len(data_params),
+    )
+    return rendered_code
+
+
+def render_event_dispatcher(
+    entries: List[xdr.SCSpecEventV0], class_names: List[str], union_name: str = "Event"
+):
+    # Try the most specific declaration (most declared topics) first, so a
+    # shorter declaration sharing the same prefix cannot swallow events of a
+    # longer one via the extra-trailing-topics tolerance. Ties keep spec order.
+    ordered_names = [
+        name
+        for _, name in sorted(
+            zip(entries, class_names),
+            key=lambda pair: -declared_topic_count(pair[0]),
+        )
+    ]
+    template = """
+{{ union_name }} = Union[{{ class_names | join(', ') }}]
+
+_EVENTS = [{{ ordered_names | join(', ') }}]
+
+def parse_event(
+    event: {{ event_input_type }},
+    raise_on_unparsed: bool = False,
+) -> Optional[{{ union_name }}]:
+    '''Parse an event emitted by this contract into a typed event object.
+
+    Candidates are tried most-specific first (most declared topics), then in
+    spec order; failures of intermediate candidates are part of that normal
+    disambiguation flow. Returns None if no declared event matches the topics.
+
+    If the topics match at least one declared event but every candidate fails
+    to parse, the event format has likely drifted from the spec these bindings
+    were generated from. That state is reported: a warning is logged by
+    default, or :class:`UnparsedEventError` is raised when ``raise_on_unparsed``
+    is True.
+    '''
+    failures: List[Tuple[type, Exception]] = []
+    # Decode the event once here rather than once per candidate: RPC events
+    # arrive as base64 XDR, and every candidate would otherwise re-decode all
+    # of the topics before rejecting them on the first one.
+    try:
+        _decoded = _event_topics_and_data(event)
+    except Exception:
+        return None
+    for _event_cls in _EVENTS:
+        if _event_cls.matches(_decoded):
+            try:
+                return _event_cls.parse(_decoded)
+            except Exception as exc:
+                failures.append((_event_cls, exc))
+    if failures:
+        details = "; ".join(f"{cls.__name__}: {exc!r}" for cls, exc in failures)
+        message = (
+            f"event topics matched {len(failures)} declared event(s) but none parsed "
+            f"successfully ({details}); the on-chain event format may have drifted "
+            f"from the spec these bindings were generated from"
+        )
+        if raise_on_unparsed:
+            raise UnparsedEventError(message, failures) from failures[-1][1]
+        _logger.warning(message)
+    return None
+"""
+    rendered_code = Template(template).render(
+        class_names=class_names,
+        ordered_names=ordered_names,
+        union_name=union_name,
+        event_input_type=(
+            "Union[xdr.ContractEvent, EventInfo, "
+            "Tuple[Sequence[Union[xdr.SCVal, str, bytes]], "
+            "Union[xdr.SCVal, str, bytes]]]"
+        ),
+    )
+    return rendered_code
+
+
+def render_client(
+    entries: List[xdr.SCSpecFunctionV0],
+    client_type: str,
+    resolve_udt_name: UdtNameResolver = _default_udt_name,
+):
     template = '''
 {%- if client_type == "sync" or client_type == "both" %}
 class Client(ContractClient):
@@ -498,6 +1228,8 @@ class Client(ContractClient):
         """{{ entry.doc.decode() }}"""
         {%- endif %}
         return self.invoke('{{ entry.name.sc_symbol_r.decode() if entry.name.sc_symbol_r else entry.name.sc_symbol.decode() }}', [{% for param in entry.inputs %}{{ to_scval(param.type, param.name.decode()) }}{% if not loop.last %}, {% endif %}{% endfor %}], parse_result_xdr_fn={{ parse_result_xdr_fn(entry.outputs) }}, source = source, signer = signer, base_fee = base_fee, transaction_timeout = transaction_timeout, submit_timeout = submit_timeout, simulate = simulate, restore = restore)
+    {%- else %}
+    pass
     {%- endfor %}
 {%- endif %}
 
@@ -509,23 +1241,40 @@ class ClientAsync(ContractClientAsync):
         """{{ entry.doc.decode() }}"""
         {%- endif %}
         return await self.invoke('{{ entry.name.sc_symbol_r.decode() if entry.name.sc_symbol_r else entry.name.sc_symbol.decode() }}', [{% for param in entry.inputs %}{{ to_scval(param.type, param.name.decode()) }}{% if not loop.last %}, {% endif %}{% endfor %}], parse_result_xdr_fn={{ parse_result_xdr_fn(entry.outputs) }}, source = source, signer = signer, base_fee = base_fee, transaction_timeout = transaction_timeout, submit_timeout = submit_timeout, simulate = simulate, restore = restore)
+    {%- else %}
+    pass
     {%- endfor %}
 {%- endif %}
 '''
+
+    def function_output(td: xdr.SCSpecTypeDef) -> xdr.SCSpecTypeDef:
+        """Strip a top-level Result wrapper from a function's return type.
+
+        A contract function declared ``Result<T, E>`` never hands back an
+        SCV_ERROR on success: returning ``Err`` traps the invocation, and the
+        SDK surfaces that as an exception (e.g. SimulationFailedError). So the
+        value reaching parse_result_xdr_fn is always the Ok arm. Nested Result
+        values keep both arms, since those really can carry an SCV_ERROR.
+        """
+        if td.type == xdr.SCSpecType.SC_SPEC_TYPE_RESULT:
+            return td.result.ok_type
+        return td
 
     def parse_result_type(output: List[xdr.SCSpecTypeDef]):
         if len(output) == 0:
             return "None"
         elif len(output) == 1:
-            return to_py_type(output[0])
+            return to_py_type(
+                function_output(output[0]), resolve_udt_name=resolve_udt_name
+            )
         else:
-            return f"Tuple[{', '.join([to_py_type(t) for t in output])}]"
+            return f"Tuple[{', '.join([to_py_type(function_output(t), resolve_udt_name=resolve_udt_name) for t in output])}]"
 
     def parse_result_xdr_fn(output: List[xdr.SCSpecTypeDef]):
         if len(output) == 0:
             return "lambda _: None"
         elif len(output) == 1:
-            return f'lambda v: {from_scval(output[0], "v")}'
+            return f'lambda v: {from_scval(function_output(output[0]), "v", resolve_udt_name)}'
         else:
             raise NotImplementedError(
                 "Tuple return type is not supported, please report this issue"
@@ -533,8 +1282,10 @@ class ClientAsync(ContractClientAsync):
 
     client_rendered_code = Template(template).render(
         entries=entries,
-        to_py_type=to_py_type,
-        to_scval=to_scval,
+        to_py_type=lambda td, input_type=False: to_py_type(
+            td, input_type, resolve_udt_name
+        ),
+        to_scval=lambda td, name: to_scval(td, name, resolve_udt_name),
         parse_result_type=parse_result_type,
         parse_result_xdr_fn=parse_result_xdr_fn,
         client_type=client_type,
@@ -602,25 +1353,61 @@ def append_underscore(specs: List[xdr.SCSpecEntry]):
                     error_enum_case.name = error_enum_case.name + b"_"
 
 
-def generate_binding(specs: List[xdr.SCSpecEntry], client_type: str) -> str:
+def generate_binding_with_diagnostics(
+    specs: List[xdr.SCSpecEntry], client_type: str
+) -> Tuple[str, List[str]]:
+    """Generate bindings plus printable notes about duplicate or renamed events.
+
+    ``client_type`` is "sync", "async" or "both"; anything else (the tests and
+    the corpus checker pass "none") skips client generation entirely.
+    """
     append_underscore(specs)
 
+    event_specs: List[xdr.SCSpecEventV0] = [
+        spec.event_v0
+        for spec in specs
+        if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_EVENT_V0
+    ]
+    udt_names = resolve_udt_names(specs)
+    resolve_udt_name = _udt_reference_resolver(udt_names)
+
     generated = []
-    generated.append(render_info())
-    generated.append(render_imports(client_type))
+    diagnostics: List[str] = []
 
     for spec in specs:
         if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0:
-            generated.append(render_enum(spec.udt_enum_v0))
+            name = udt_names[spec.udt_enum_v0.name.decode()]
+            generated.append(render_enum(spec.udt_enum_v0, name))
         if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0:
-            generated.append(render_error_enum(spec.udt_error_enum_v0))
+            name = udt_names[spec.udt_error_enum_v0.name.decode()]
+            generated.append(render_error_enum(spec.udt_error_enum_v0, name))
         if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0:
+            name = udt_names[spec.udt_struct_v0.name.decode()]
             if is_tuple_struct(spec.udt_struct_v0):
-                generated.append(render_tuple_struct(spec.udt_struct_v0))
+                generated.append(
+                    render_tuple_struct(spec.udt_struct_v0, name, resolve_udt_name)
+                )
             else:
-                generated.append(render_struct(spec.udt_struct_v0))
+                generated.append(
+                    render_struct(spec.udt_struct_v0, name, resolve_udt_name)
+                )
         if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0:
-            generated.append(render_union(spec.udt_union_v0))
+            name = udt_names[spec.udt_union_v0.name.decode()]
+            generated.append(render_union(spec.udt_union_v0, name, resolve_udt_name))
+
+    if event_specs:
+        event_class_names, event_union_name = resolve_event_names(
+            specs, event_specs, udt_names
+        )
+        diagnostics = event_diagnostics(event_specs, event_class_names)
+        generated.append(render_event_helpers())
+        for event_spec, event_cls_name in zip(event_specs, event_class_names):
+            generated.append(render_event(event_spec, event_cls_name, resolve_udt_name))
+        generated.append(
+            render_event_dispatcher(
+                event_specs, event_class_names, union_name=event_union_name
+            )
+        )
 
     function_specs: List[xdr.SCSpecFunctionV0] = [
         spec.function_v0
@@ -628,8 +1415,22 @@ def generate_binding(specs: List[xdr.SCSpecEntry], client_type: str) -> str:
         if spec.kind == xdr.SCSpecEntryKind.SC_SPEC_ENTRY_FUNCTION_V0
         and not spec.function_v0.name.sc_symbol.decode().startswith("__")
     ]
-    generated.append(render_client(function_specs, client_type))
-    return "\n".join(generated)
+    generated.append(render_client(function_specs, client_type, resolve_udt_name))
+
+    body = "\n".join(generated)
+    header = [
+        render_info(),
+        render_imports(client_type, has_events=bool(event_specs)),
+    ]
+    # Error enums and SC_SPEC_TYPE_ERROR values are the only users of the
+    # error helper, and both are rare; emit it only when the body calls it.
+    if "_from_error_scval(" in body:
+        header.append(render_scval_helpers())
+    return "\n".join(header + [body]), diagnostics
+
+
+def generate_binding(specs: List[xdr.SCSpecEntry], client_type: str) -> str:
+    return generate_binding_with_diagnostics(specs, client_type)[0]
 
 
 @click.command(name="python")
@@ -666,7 +1467,11 @@ def command(contract_id: str, rpc_url: str, output: str, client_type: str):
         raise click.Abort()
 
     click.echo("Generating Python bindings")
-    generated = generate_binding(specs, client_type=client_type)
+    generated, diagnostics = generate_binding_with_diagnostics(
+        specs, client_type=client_type
+    )
+    for diagnostic in diagnostics:
+        click.echo(diagnostic, err=True)
     try:
         generated = black.format_str(generated, mode=black.Mode())
     except Exception as e:
@@ -674,6 +1479,7 @@ def command(contract_id: str, rpc_url: str, output: str, client_type: str):
             f"formatting failed, there may be issues with the generated binding, please report to us: {e}",
             err=True,
         )
+        raise click.Abort()
 
     if not os.path.exists(output):
         os.makedirs(output)

--- a/tests/test_python_event_bindings.py
+++ b/tests/test_python_event_bindings.py
@@ -1,0 +1,1464 @@
+import ast
+import logging
+from pathlib import Path
+
+import black
+import pytest
+from click.testing import CliRunner
+from stellar_sdk import Address, scval, xdr
+from stellar_sdk.soroban_rpc import EventInfo
+
+from stellar_contract_bindings.metadata import get_token_sc_spec_entry
+from stellar_contract_bindings.python import (
+    _GENERATED_MODULE_NAMES,
+    command,
+    event_class_name,
+    generate_binding,
+    generate_binding_with_diagnostics,
+    render_event_helpers,
+    render_imports,
+    render_scval_helpers,
+)
+
+FROM_ADDRESS = "GBMBVAHBE6D4AJXJJVTBQTVU4G7SN4FEIJOL5YTOHZ4WCUMKQ52ANL2B"
+TO_ADDRESS = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+CONTRACT_ID = "CBUZJXHZ6PBS2YR3SEJZ3CIGMQBYP6367D3KQAR2NB3U2I5AOWLC4DU2"
+
+
+def _type(t: xdr.SCSpecType) -> xdr.SCSpecTypeDef:
+    return xdr.SCSpecTypeDef(t)
+
+
+def _vec_type(element_type: xdr.SCSpecTypeDef) -> xdr.SCSpecTypeDef:
+    td = xdr.SCSpecTypeDef(xdr.SCSpecType.SC_SPEC_TYPE_VEC)
+    td.vec = xdr.SCSpecTypeVec(element_type)
+    return td
+
+
+def _udt_type(name: bytes) -> xdr.SCSpecTypeDef:
+    return xdr.SCSpecTypeDef(
+        xdr.SCSpecType.SC_SPEC_TYPE_UDT,
+        udt=xdr.SCSpecTypeUDT(name=name),
+    )
+
+
+def _option_type(value_type: xdr.SCSpecTypeDef) -> xdr.SCSpecTypeDef:
+    return xdr.SCSpecTypeDef(
+        xdr.SCSpecType.SC_SPEC_TYPE_OPTION,
+        option=xdr.SCSpecTypeOption(value_type=value_type),
+    )
+
+
+def _result_type(
+    ok_type: xdr.SCSpecTypeDef, error_type: xdr.SCSpecTypeDef
+) -> xdr.SCSpecTypeDef:
+    return xdr.SCSpecTypeDef(
+        xdr.SCSpecType.SC_SPEC_TYPE_RESULT,
+        result=xdr.SCSpecTypeResult(ok_type=ok_type, error_type=error_type),
+    )
+
+
+def _contract_error(code: int) -> xdr.SCVal:
+    return xdr.SCVal(
+        xdr.SCValType.SCV_ERROR,
+        error=xdr.SCError(
+            xdr.SCErrorType.SCE_CONTRACT,
+            contract_code=xdr.Uint32(code),
+        ),
+    )
+
+
+def _struct(name: bytes, field_type: xdr.SCSpecTypeDef) -> xdr.SCSpecEntry:
+    return xdr.SCSpecEntry(
+        xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0,
+        udt_struct_v0=xdr.SCSpecUDTStructV0(
+            doc=b"",
+            lib=b"",
+            name=name,
+            fields=[
+                xdr.SCSpecUDTStructFieldV0(doc=b"", name=b"value", type=field_type)
+            ],
+        ),
+    )
+
+
+def _event_param(
+    name: bytes,
+    td: xdr.SCSpecTypeDef,
+    location: xdr.SCSpecEventParamLocationV0,
+) -> xdr.SCSpecEventParamV0:
+    return xdr.SCSpecEventParamV0(doc=b"", name=name, type=td, location=location)
+
+
+def _topic_param(name: bytes, td: xdr.SCSpecTypeDef) -> xdr.SCSpecEventParamV0:
+    return _event_param(
+        name,
+        td,
+        xdr.SCSpecEventParamLocationV0.SC_SPEC_EVENT_PARAM_LOCATION_TOPIC_LIST,
+    )
+
+
+def _data_param(name: bytes, td: xdr.SCSpecTypeDef) -> xdr.SCSpecEventParamV0:
+    return _event_param(
+        name, td, xdr.SCSpecEventParamLocationV0.SC_SPEC_EVENT_PARAM_LOCATION_DATA
+    )
+
+
+def _event(
+    name: bytes,
+    prefix_topics: list[bytes],
+    params: list[xdr.SCSpecEventParamV0],
+    data_format: xdr.SCSpecEventDataFormat,
+) -> xdr.SCSpecEntry:
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_EVENT_V0)
+    entry.event_v0 = xdr.SCSpecEventV0(
+        doc=b"",
+        lib=b"",
+        name=xdr.SCSymbol(sc_symbol=name),
+        prefix_topics=[xdr.SCSymbol(sc_symbol=t) for t in prefix_topics],
+        params=params,
+        data_format=data_format,
+    )
+    return entry
+
+
+def _contract_event(topics: list[xdr.SCVal], data: xdr.SCVal) -> xdr.ContractEvent:
+    return xdr.ContractEvent(
+        ext=xdr.ExtensionPoint(0),
+        contract_id=xdr.ContractID(
+            xdr.Hash(Address(CONTRACT_ID).key),
+        ),
+        type=xdr.ContractEventType.CONTRACT,
+        body=xdr.ContractEventBody(0, v0=xdr.ContractEventV0(topics=topics, data=data)),
+    )
+
+
+def _event_info(topics: list[str], value: str) -> EventInfo:
+    """Build an RPC getEvents entry, whose topics/value are base64 XDR."""
+    return EventInfo.model_validate(
+        {
+            "type": "contract",
+            "ledger": 1,
+            "ledgerClosedAt": "2026-07-21T00:00:00Z",
+            "contractId": CONTRACT_ID,
+            "id": "0000000001-0000000000",
+            "topic": topics,
+            "value": value,
+            "inSuccessfulContractCall": True,
+            "operationIndex": 0,
+            "transactionIndex": 0,
+            "txHash": "a" * 64,
+        }
+    )
+
+
+def _top_level_bindings(tree: ast.Module) -> set[str]:
+    """Names bound at module scope in generated source."""
+    bindings = set()
+    for node in tree.body:
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            bindings.add(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            for alias in node.names:
+                bindings.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, ast.Assign):
+            bindings.update(
+                target.id for target in node.targets if isinstance(target, ast.Name)
+            )
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            bindings.add(node.target.id)
+    return bindings
+
+
+def _load_bindings(specs: list[xdr.SCSpecEntry]) -> dict:
+    code = generate_binding(specs, client_type="none")
+    code = black.format_str(code, mode=black.Mode())
+    namespace: dict = {}
+    exec(compile(code, "bindings.py", "exec"), namespace)
+    return namespace
+
+
+class TestEventClassName:
+    def test_snake_case(self):
+        assert event_class_name("approve") == "ApproveEvent"
+        assert event_class_name("set_admin") == "SetAdminEvent"
+
+    def test_pascal_case(self):
+        assert event_class_name("Transfer") == "TransferEvent"
+        assert event_class_name("TransferWithMuxedString") == (
+            "TransferWithMuxedStringEvent"
+        )
+
+    def test_existing_suffix_not_duplicated(self):
+        assert event_class_name("TransferEvent") == "TransferEvent"
+        assert event_class_name("transfer_event") == "TransferEvent"
+
+
+class TestSingleValueFormat:
+    def setup_method(self):
+        specs = [
+            _event(
+                b"approve",
+                [b"approve"],
+                [
+                    _topic_param(b"from", _type(xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS)),
+                    _data_param(b"amount", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            )
+        ]
+        self.ns = _load_bindings(specs)
+
+    def test_parse(self):
+        event = _contract_event(
+            [scval.to_symbol("approve"), scval.to_address(FROM_ADDRESS)],
+            scval.to_int128(10000),
+        )
+        parsed = self.ns["ApproveEvent"].parse(event)
+        assert parsed.from_ == Address(FROM_ADDRESS)
+        assert parsed.amount == 10000
+
+    def test_matches_rejects_wrong_prefix(self):
+        event = _contract_event(
+            [scval.to_symbol("transfer"), scval.to_address(FROM_ADDRESS)],
+            scval.to_int128(10000),
+        )
+        assert not self.ns["ApproveEvent"].matches(event)
+
+    def test_matches_rejects_missing_topics(self):
+        event = _contract_event([scval.to_symbol("approve")], scval.to_int128(10000))
+        assert not self.ns["ApproveEvent"].matches(event)
+
+    def test_extra_trailing_topics_ignored(self):
+        # On-chain events may carry topics beyond the SEP-48 declaration,
+        # e.g. SAC events append the SEP-11 asset string.
+        event = _contract_event(
+            [
+                scval.to_symbol("approve"),
+                scval.to_address(FROM_ADDRESS),
+                scval.to_string("native"),
+            ],
+            scval.to_int128(10000),
+        )
+        parsed = self.ns["ApproveEvent"].parse(event)
+        assert parsed.from_ == Address(FROM_ADDRESS)
+        assert parsed.amount == 10000
+
+    def test_parse_raises_on_mismatch(self):
+        event = _contract_event([scval.to_symbol("other")], scval.to_void())
+        with pytest.raises(ValueError, match="does not match ApproveEvent"):
+            self.ns["ApproveEvent"].parse(event)
+
+    def test_equality_and_hash(self):
+        event = _contract_event(
+            [scval.to_symbol("approve"), scval.to_address(FROM_ADDRESS)],
+            scval.to_int128(10000),
+        )
+        a = self.ns["ApproveEvent"].parse(event)
+        b = self.ns["ApproveEvent"].parse(event)
+        assert a == b
+        assert hash(a) == hash(b)
+
+    def test_typed_topic_filter(self):
+        wildcard = self.ns["ApproveEvent"].topic_filter()
+        assert wildcard == [scval.to_symbol("approve").to_xdr(), "*", "**"]
+
+        exact = self.ns["ApproveEvent"].topic_filter(from_=FROM_ADDRESS)
+        assert exact == [
+            scval.to_symbol("approve").to_xdr(),
+            scval.to_address(FROM_ADDRESS).to_xdr(),
+            "**",
+        ]
+
+    def test_parse_raw_scvals(self):
+        parsed = self.ns["parse_event"](
+            (
+                [scval.to_symbol("approve"), scval.to_address(FROM_ADDRESS)],
+                scval.to_int128(10000),
+            )
+        )
+        assert isinstance(parsed, self.ns["ApproveEvent"])
+        assert parsed.from_ == Address(FROM_ADDRESS)
+        assert parsed.amount == 10000
+
+    def test_parse_raw_base64_xdr(self):
+        raw_event = (
+            [
+                scval.to_symbol("approve").to_xdr(),
+                scval.to_address(FROM_ADDRESS).to_xdr(),
+            ],
+            scval.to_int128(10000).to_xdr(),
+        )
+        parsed = self.ns["ApproveEvent"].parse(raw_event)
+        assert parsed.from_ == Address(FROM_ADDRESS)
+        assert parsed.amount == 10000
+
+    def test_parse_raw_binary_xdr(self):
+        raw_event = (
+            [
+                scval.to_symbol("approve").to_xdr_bytes(),
+                scval.to_address(FROM_ADDRESS).to_xdr_bytes(),
+            ],
+            scval.to_int128(10000).to_xdr_bytes(),
+        )
+        parsed = self.ns["ApproveEvent"].parse(raw_event)
+        assert parsed.from_ == Address(FROM_ADDRESS)
+        assert parsed.amount == 10000
+
+    def test_malformed_raw_xdr_returns_none(self):
+        assert self.ns["parse_event"]((["not base64 xdr"], "also invalid")) is None
+
+
+class TestVecFormat:
+    def setup_method(self):
+        specs = [
+            _event(
+                b"swap",
+                [b"swap"],
+                [
+                    _data_param(b"amount_in", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128)),
+                    _data_param(b"amount_out", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_VEC,
+            )
+        ]
+        self.ns = _load_bindings(specs)
+
+    def test_parse(self):
+        event = _contract_event(
+            [scval.to_symbol("swap")],
+            scval.to_vec([scval.to_int128(5), scval.to_int128(7)]),
+        )
+        parsed = self.ns["SwapEvent"].parse(event)
+        assert parsed.amount_in == 5
+        assert parsed.amount_out == 7
+
+
+class TestMapFormat:
+    def setup_method(self):
+        specs = [
+            _event(
+                b"transfer",
+                [b"transfer"],
+                [
+                    _topic_param(b"from", _type(xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS)),
+                    _topic_param(b"to", _type(xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS)),
+                    _data_param(b"amount", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_MAP,
+            )
+        ]
+        self.ns = _load_bindings(specs)
+
+    def test_parse(self):
+        event = _contract_event(
+            [
+                scval.to_symbol("transfer"),
+                scval.to_address(FROM_ADDRESS),
+                scval.to_address(TO_ADDRESS),
+            ],
+            scval.to_struct({"amount": scval.to_int128(42)}),
+        )
+        parsed = self.ns["TransferEvent"].parse(event)
+        assert parsed.from_ == Address(FROM_ADDRESS)
+        assert parsed.to == Address(TO_ADDRESS)
+        assert parsed.amount == 42
+
+    def test_missing_required_map_entry_is_rejected(self):
+        # ``amount`` is declared without an option wrapper, so an event that
+        # omits it does not satisfy the declaration and must not parse into a
+        # TransferEvent with amount=None.
+        event = _contract_event(
+            [
+                scval.to_symbol("transfer"),
+                scval.to_address(FROM_ADDRESS),
+                scval.to_address(TO_ADDRESS),
+            ],
+            scval.to_struct({}),
+        )
+        with pytest.raises(ValueError, match="missing required entries"):
+            self.ns["TransferEvent"].parse(event)
+
+    def test_extra_map_entry_is_ignored(self):
+        event = _contract_event(
+            [
+                scval.to_symbol("transfer"),
+                scval.to_address(FROM_ADDRESS),
+                scval.to_address(TO_ADDRESS),
+            ],
+            scval.to_struct(
+                {"amount": scval.to_int128(42), "future_field": scval.to_uint32(1)}
+            ),
+        )
+        assert self.ns["TransferEvent"].parse(event).amount == 42
+
+    def test_absent_optional_map_entry_is_none(self):
+        specs = [
+            _event(
+                b"tagged",
+                [b"tagged"],
+                [
+                    _data_param(b"amount", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128)),
+                    _data_param(
+                        b"memo", _option_type(_type(xdr.SCSpecType.SC_SPEC_TYPE_U32))
+                    ),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_MAP,
+            )
+        ]
+        ns = _load_bindings(specs)
+        event = _contract_event(
+            [scval.to_symbol("tagged")],
+            scval.to_struct({"amount": scval.to_int128(42)}),
+        )
+        parsed = ns["TaggedEvent"].parse(event)
+        assert parsed.amount == 42
+        assert parsed.memo is None
+
+
+class TestNoParams:
+    def setup_method(self):
+        specs = [
+            _event(
+                b"paused",
+                [b"paused"],
+                [],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            )
+        ]
+        self.ns = _load_bindings(specs)
+
+    def test_parse(self):
+        event = _contract_event([scval.to_symbol("paused")], scval.to_void())
+        parsed = self.ns["PausedEvent"].parse(event)
+        assert parsed == self.ns["PausedEvent"]()
+
+    def test_non_void_data_is_rejected(self):
+        event = _contract_event([scval.to_symbol("paused")], scval.to_uint32(1))
+        with pytest.raises(ValueError):
+            self.ns["PausedEvent"].parse(event)
+
+    def test_topic_filter_contains_only_static_prefixes(self):
+        assert self.ns["PausedEvent"].topic_filter() == [
+            scval.to_symbol("paused").to_xdr(),
+            "**",
+        ]
+
+
+class TestResultAndErrorTypes:
+    def test_generic_error_event_param_round_trips(self):
+        specs = [
+            _event(
+                b"failed",
+                [b"failed"],
+                [_data_param(b"error", _type(xdr.SCSpecType.SC_SPEC_TYPE_ERROR))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            )
+        ]
+        ns = _load_bindings(specs)
+        raw_error = _contract_error(7)
+        parsed = ns["FailedEvent"].parse(
+            _contract_event([scval.to_symbol("failed")], raw_error)
+        )
+        assert parsed.error == raw_error.error
+
+    def test_result_with_generic_error_parses_both_arms(self):
+        result_type = _result_type(
+            _type(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+            _type(xdr.SCSpecType.SC_SPEC_TYPE_ERROR),
+        )
+        specs = [
+            _event(
+                b"outcome",
+                [b"outcome"],
+                [_data_param(b"result", result_type)],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            )
+        ]
+        ns = _load_bindings(specs)
+
+        ok = ns["OutcomeEvent"].parse(
+            _contract_event([scval.to_symbol("outcome")], scval.to_uint32(3))
+        )
+        assert ok.result == 3
+
+        raw_error = _contract_error(9)
+        failed = ns["OutcomeEvent"].parse(
+            _contract_event([scval.to_symbol("outcome")], raw_error)
+        )
+        assert failed.result == raw_error.error
+
+    def test_result_with_generic_error_builds_topic_filters(self):
+        result_type = _result_type(
+            _type(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+            _type(xdr.SCSpecType.SC_SPEC_TYPE_ERROR),
+        )
+        ns = _load_bindings(
+            [
+                _event(
+                    b"outcome",
+                    [b"outcome"],
+                    [_topic_param(b"result", result_type)],
+                    xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+                )
+            ]
+        )
+        raw_error = _contract_error(9)
+        assert (
+            ns["OutcomeEvent"].topic_filter(result=3)[1] == scval.to_uint32(3).to_xdr()
+        )
+        assert (
+            ns["OutcomeEvent"].topic_filter(result=raw_error.error)[1]
+            == raw_error.to_xdr()
+        )
+
+    def test_result_with_error_enum_supports_topic_filters(self):
+        error_entry = xdr.SCSpecEntry(
+            xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0,
+            udt_error_enum_v0=xdr.SCSpecUDTErrorEnumV0(
+                doc=b"",
+                lib=b"",
+                name=b"ContractError",
+                cases=[
+                    xdr.SCSpecUDTErrorEnumCaseV0(
+                        doc=b"", name=b"Denied", value=xdr.Uint32(4)
+                    )
+                ],
+            ),
+        )
+        result_type = _result_type(
+            _type(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+            _udt_type(b"ContractError"),
+        )
+        specs = [
+            error_entry,
+            _event(
+                b"outcome",
+                [b"outcome"],
+                [_topic_param(b"result", result_type)],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        ns = _load_bindings(specs)
+        expected_error = _contract_error(4)
+        assert ns["OutcomeEvent"].topic_filter(result=ns["ContractError"].Denied) == [
+            scval.to_symbol("outcome").to_xdr(),
+            expected_error.to_xdr(),
+            "**",
+        ]
+
+        parsed = ns["OutcomeEvent"].parse(
+            _contract_event(
+                [scval.to_symbol("outcome"), expected_error], scval.to_void()
+            )
+        )
+        assert parsed.result is ns["ContractError"].Denied
+
+
+class TestFunctionResultOutputs:
+    """A function's ``Result<T, E>`` return arrives as T; ``Err`` traps the
+    invocation instead of being handed back as an SCV_ERROR value."""
+
+    def _client(self, output: xdr.SCSpecTypeDef) -> str:
+        fn = xdr.SCSpecEntry(
+            xdr.SCSpecEntryKind.SC_SPEC_ENTRY_FUNCTION_V0,
+            function_v0=xdr.SCSpecFunctionV0(
+                doc=b"",
+                name=xdr.SCSymbol(sc_symbol=b"probe"),
+                inputs=[],
+                outputs=[output],
+            ),
+        )
+        return generate_binding([fn], client_type="sync")
+
+    def test_top_level_result_exposes_only_ok_type(self):
+        code = self._client(
+            _result_type(
+                _type(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+                _type(xdr.SCSpecType.SC_SPEC_TYPE_ERROR),
+            )
+        )
+        assert "AssembledTransaction[int]" in code
+        assert "parse_result_xdr_fn=lambda v: scval.from_uint32(v)" in code
+        invoke_line = next(line for line in code.splitlines() if "self.invoke(" in line)
+        assert "SCV_ERROR" not in invoke_line
+
+    def test_nested_result_keeps_both_arms(self):
+        code = self._client(
+            _vec_type(
+                _result_type(
+                    _type(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+                    _type(xdr.SCSpecType.SC_SPEC_TYPE_ERROR),
+                )
+            )
+        )
+        assert "AssembledTransaction[List[Union[int, xdr.SCError]]]" in code
+        assert "SCV_ERROR" in code
+
+
+class TestParseEventDispatcher:
+    def setup_method(self):
+        specs = [
+            _event(
+                b"approve",
+                [b"approve"],
+                [
+                    _topic_param(b"from", _type(xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS)),
+                    _data_param(b"amount", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+            # Same topic shape as the next event; disambiguated by data type.
+            _event(
+                b"deposit_i128",
+                [b"deposit"],
+                [_data_param(b"amount", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+            _event(
+                b"deposit_str",
+                [b"deposit"],
+                [_data_param(b"memo", _type(xdr.SCSpecType.SC_SPEC_TYPE_STRING))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        self.ns = _load_bindings(specs)
+
+    def test_dispatch(self):
+        event = _contract_event(
+            [scval.to_symbol("approve"), scval.to_address(FROM_ADDRESS)],
+            scval.to_int128(10000),
+        )
+        parsed = self.ns["parse_event"](event)
+        assert isinstance(parsed, self.ns["ApproveEvent"])
+
+    def test_dispatch_disambiguates_by_data(self):
+        i128_event = _contract_event(
+            [scval.to_symbol("deposit")], scval.to_int128(10000)
+        )
+        str_event = _contract_event(
+            [scval.to_symbol("deposit")], scval.to_string("hello")
+        )
+        assert isinstance(
+            self.ns["parse_event"](i128_event), self.ns["DepositI128Event"]
+        )
+        assert isinstance(self.ns["parse_event"](str_event), self.ns["DepositStrEvent"])
+
+    def test_dispatch_unknown_event_returns_none(self, caplog):
+        event = _contract_event([scval.to_symbol("unknown")], scval.to_void())
+        with caplog.at_level(logging.WARNING):
+            assert self.ns["parse_event"](event) is None
+        # A genuinely undeclared event is not an error condition.
+        assert not caplog.records
+
+    def test_dispatch_success_after_intermediate_failure_is_silent(self, caplog):
+        # deposit_i128 fails on string data before deposit_str succeeds;
+        # that intermediate failure is normal disambiguation, not a problem.
+        event = _contract_event([scval.to_symbol("deposit")], scval.to_string("hello"))
+        with caplog.at_level(logging.WARNING):
+            parsed = self.ns["parse_event"](event)
+        assert isinstance(parsed, self.ns["DepositStrEvent"])
+        assert not caplog.records
+
+    def test_dispatch_matched_but_unparseable_logs_warning(self, caplog):
+        # Topics match ApproveEvent, but the data is a bool instead of the
+        # declared i128 — e.g. the contract's event format drifted.
+        event = _contract_event(
+            [scval.to_symbol("approve"), scval.to_address(FROM_ADDRESS)],
+            scval.to_bool(True),
+        )
+        with caplog.at_level(logging.WARNING):
+            assert self.ns["parse_event"](event) is None
+        assert len(caplog.records) == 1
+        assert "ApproveEvent" in caplog.records[0].message
+        assert "drifted" in caplog.records[0].message
+
+    def test_dispatch_matched_but_unparseable_raises_when_requested(self):
+        event = _contract_event(
+            [scval.to_symbol("approve"), scval.to_address(FROM_ADDRESS)],
+            scval.to_bool(True),
+        )
+        with pytest.raises(self.ns["UnparsedEventError"]) as exc_info:
+            self.ns["parse_event"](event, raise_on_unparsed=True)
+        failures = exc_info.value.failures
+        assert len(failures) == 1
+        assert failures[0][0] is self.ns["ApproveEvent"]
+        assert isinstance(failures[0][1], ValueError)
+        assert exc_info.value.__cause__ is failures[0][1]
+
+    def test_event_info_values_are_decoded_once(self):
+        # parse_event normalizes up front so candidates share one decode;
+        # otherwise every candidate re-decodes the base64 topics before
+        # rejecting them.
+        decoded = []
+        coerce = self.ns["_coerce_event_scval"]
+
+        def counting_coerce(value):
+            if not isinstance(value, xdr.SCVal):
+                decoded.append(value)
+            return coerce(value)
+
+        self.ns["_coerce_event_scval"] = counting_coerce
+        try:
+            info = _event_info(
+                [
+                    scval.to_symbol("approve").to_xdr(),
+                    scval.to_address(FROM_ADDRESS).to_xdr(),
+                ],
+                scval.to_int128(10000).to_xdr(),
+            )
+            assert isinstance(self.ns["parse_event"](info), self.ns["ApproveEvent"])
+        finally:
+            self.ns["_coerce_event_scval"] = coerce
+        assert len(decoded) == 3  # 2 topics + 1 data value, each decoded once
+
+    def test_dispatch_event_info(self):
+        event_info = _event_info(
+            [
+                scval.to_symbol("approve").to_xdr(),
+                scval.to_address(FROM_ADDRESS).to_xdr(),
+            ],
+            scval.to_int128(10000).to_xdr(),
+        )
+        parsed = self.ns["parse_event"](event_info)
+        assert isinstance(parsed, self.ns["ApproveEvent"])
+        assert parsed.amount == 10000
+
+    def test_malformed_event_info_does_not_escape_decoder_errors(self):
+        assert self.ns["parse_event"](_event_info(["AAAA"], "AAAA")) is None
+
+    def test_dispatch_continues_after_assertion_error(self):
+        event = _contract_event([scval.to_symbol("deposit")], scval.to_string("ok"))
+
+        def fail_with_assertion(cls, event):
+            raise AssertionError("invalid UDT union payload")
+
+        self.ns["DepositI128Event"].parse = classmethod(fail_with_assertion)
+        parsed = self.ns["parse_event"](event)
+        assert isinstance(parsed, self.ns["DepositStrEvent"])
+
+
+class TestStringPrefixTopics:
+    """SEP-48: parsers should tolerate static topics being SCV_SYMBOL or SCV_STRING."""
+
+    def setup_method(self):
+        specs = [
+            _event(
+                b"approve",
+                [b"approve"],
+                [
+                    _topic_param(b"from", _type(xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS)),
+                    _data_param(b"amount", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            )
+        ]
+        self.ns = _load_bindings(specs)
+
+    def test_string_prefix_topic_matches(self):
+        event = _contract_event(
+            [scval.to_string("approve"), scval.to_address(FROM_ADDRESS)],
+            scval.to_int128(10000),
+        )
+        parsed = self.ns["ApproveEvent"].parse(event)
+        assert parsed.amount == 10000
+
+    def test_non_symbol_non_string_prefix_rejected(self):
+        event = _contract_event(
+            [scval.to_uint32(1), scval.to_address(FROM_ADDRESS)],
+            scval.to_int128(10000),
+        )
+        assert not self.ns["ApproveEvent"].matches(event)
+
+
+class TestSpecificityOrdering:
+    """A shorter declaration sharing a prefix must not swallow events of a
+    longer declaration via the extra-trailing-topics tolerance."""
+
+    def setup_method(self):
+        specs = [
+            # Declared shorter event first in spec order on purpose.
+            _event(
+                b"foo_short",
+                [b"foo"],
+                [
+                    _topic_param(b"addr", _type(xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS)),
+                    _data_param(b"amount", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+            _event(
+                b"foo_long",
+                [b"foo"],
+                [
+                    _topic_param(b"addr", _type(xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS)),
+                    _topic_param(b"index", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                    _data_param(b"amount", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        self.ns = _load_bindings(specs)
+
+    def test_longer_event_wins_over_shorter_declaration(self):
+        event = _contract_event(
+            [
+                scval.to_symbol("foo"),
+                scval.to_address(FROM_ADDRESS),
+                scval.to_uint32(7),
+            ],
+            scval.to_int128(10000),
+        )
+        parsed = self.ns["parse_event"](event)
+        assert isinstance(parsed, self.ns["FooLongEvent"])
+        assert parsed.index == 7
+
+    def test_shorter_event_still_parses(self):
+        event = _contract_event(
+            [scval.to_symbol("foo"), scval.to_address(FROM_ADDRESS)],
+            scval.to_int128(10000),
+        )
+        parsed = self.ns["parse_event"](event)
+        assert isinstance(parsed, self.ns["FooShortEvent"])
+
+
+class TestClassNameCollisions:
+    def test_event_named_event_does_not_overwrite_union_alias(self):
+        specs = [
+            _event(
+                b"event",
+                [b"event"],
+                [_data_param(b"value", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            )
+        ]
+        ns = _load_bindings(specs)
+        event = _contract_event([scval.to_symbol("event")], scval.to_uint32(7))
+        parsed = ns["parse_event"](event)
+        assert isinstance(ns["Event_"], type)
+        assert isinstance(parsed, ns["Event_"])
+        assert parsed.value == 7
+
+    def test_udt_named_event_is_not_overwritten_by_union_alias(self):
+        struct_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+        struct_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+            doc=b"",
+            lib=b"",
+            name=b"Event",
+            fields=[
+                xdr.SCSpecUDTStructFieldV0(
+                    doc=b"",
+                    name=b"value",
+                    type=_type(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+                )
+            ],
+        )
+        specs = [
+            struct_entry,
+            _event(
+                b"foo",
+                [b"foo"],
+                [_data_param(b"value", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        ns = _load_bindings(specs)
+        assert hasattr(ns["Event"], "from_scval")
+        assert ns["Event_"] == ns["FooEvent"]
+
+    def test_event_names_normalizing_identically(self):
+        specs = [
+            _event(
+                b"foo",
+                [b"foo"],
+                [_data_param(b"a", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+            _event(
+                b"foo_event",
+                [b"bar"],
+                [_data_param(b"a", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        ns = _load_bindings(specs)
+        assert isinstance(ns["FooEvent"], type)
+        assert isinstance(ns["FooEvent_"], type)
+        event = _contract_event([scval.to_symbol("bar")], scval.to_uint32(2))
+        parsed = ns["parse_event"](event)
+        assert isinstance(parsed, ns["FooEvent_"])
+
+        _, diagnostics = generate_binding_with_diagnostics(specs, client_type="none")
+        assert diagnostics == [
+            "Event binding note: 'foo_event' -> FooEvent_ "
+            "(renamed to avoid a generated-name collision)"
+        ]
+
+    def test_event_name_colliding_with_udt(self):
+        struct_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+        struct_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+            doc=b"",
+            lib=b"",
+            name=b"FooEvent",
+            fields=[
+                xdr.SCSpecUDTStructFieldV0(
+                    doc=b"",
+                    name=b"a",
+                    type=_type(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+                )
+            ],
+        )
+        udt_type = xdr.SCSpecTypeDef(xdr.SCSpecType.SC_SPEC_TYPE_UDT)
+        udt_type.udt = xdr.SCSpecTypeUDT(name=b"FooEvent")
+        specs = [
+            struct_entry,
+            _event(
+                b"foo",
+                [b"foo"],
+                [_data_param(b"payload", udt_type)],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        ns = _load_bindings(specs)
+        # The UDT keeps its name; the event is renamed out of its way.
+        assert hasattr(ns["FooEvent"], "from_scval")
+        event = _contract_event(
+            [scval.to_symbol("foo")],
+            scval.to_struct({"a": scval.to_uint32(5)}),
+        )
+        parsed = ns["parse_event"](event)
+        assert isinstance(parsed, ns["FooEvent_"])
+        assert parsed.payload.a == 5
+
+
+class TestQualifiedUdtNames:
+    def test_unambiguous_qualified_udt_uses_its_bare_name(self):
+        specs = [
+            _struct(b"test_udt::Payload", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+            _event(
+                b"changed",
+                [b"changed"],
+                [_data_param(b"payload", _udt_type(b"test_udt::Payload"))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        ns = _load_bindings(specs)
+        assert "test_udt_Payload" not in ns
+
+        event = _contract_event(
+            [scval.to_symbol("changed")],
+            scval.to_struct({"value": scval.to_uint32(7)}),
+        )
+        parsed = ns["parse_event"](event)
+        assert isinstance(parsed.payload, ns["Payload"])
+        assert parsed.payload.value == 7
+
+    def test_nested_qualified_udt_round_trips(self):
+        specs = [
+            _struct(b"test_udt::Payload", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+            _struct(b"test_udt::Envelope", _udt_type(b"test_udt::Payload")),
+        ]
+        ns = _load_bindings(specs)
+        envelope = ns["Envelope"](ns["Payload"](11))
+        decoded = ns["Envelope"].from_scval(envelope.to_scval())
+        assert isinstance(decoded.value, ns["Payload"])
+        assert decoded.value.value == 11
+
+    def test_ambiguous_bare_udt_names_use_qualified_declarations(self):
+        specs = [
+            _struct(b"first::Shared", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+            _struct(b"second::Shared", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+            _event(
+                b"changed",
+                [b"changed"],
+                [_data_param(b"payload", _udt_type(b"second::Shared"))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        ns = _load_bindings(specs)
+        assert "Shared" not in ns
+
+        event = _contract_event(
+            [scval.to_symbol("changed")],
+            scval.to_struct({"value": scval.to_uint32(8)}),
+        )
+        parsed = ns["parse_event"](event)
+        assert isinstance(parsed.payload, ns["second_Shared"])
+        assert parsed.payload.value == 8
+
+    def test_udt_name_wins_over_later_event_class_name(self):
+        # The UDT is declared first, so it keeps the bare name and the event
+        # class, which would otherwise be generated with the same name, is the
+        # one that gets renamed.
+        specs = [
+            _struct(
+                b"test_udt::TransferEvent",
+                _type(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+            ),
+            _event(
+                b"transfer",
+                [b"transfer"],
+                [_data_param(b"amount", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        ns = _load_bindings(specs)
+        assert hasattr(ns["TransferEvent"], "from_scval")
+        assert hasattr(ns["TransferEvent_"], "EVENT_NAME")
+
+    @pytest.mark.parametrize(
+        "reserved_name",
+        [b"EventInfo", b"_EVENTS", b"UnparsedEventError", b"parse_event"],
+    )
+    def test_udt_does_not_overwrite_generated_runtime(self, reserved_name):
+        specs = [
+            _struct(reserved_name, _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+            _event(
+                b"changed",
+                [b"changed"],
+                [_data_param(b"payload", _udt_type(reserved_name))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        ns = _load_bindings(specs)
+        event = _contract_event(
+            [scval.to_symbol("changed")],
+            scval.to_struct({"value": scval.to_uint32(9)}),
+        )
+        # parse_event still dispatching proves the generated runtime survived;
+        # the contract's own type lives under a renamed symbol.
+        parsed = ns["parse_event"](event)
+        assert parsed.payload.value == 9
+        assert isinstance(parsed.payload, ns[reserved_name.decode() + "2"])
+
+
+class TestReservedModuleNames:
+    def test_reserved_set_matches_what_the_generator_emits(self):
+        # _GENERATED_MODULE_NAMES is hand-maintained and is what stops a UDT or
+        # event from shadowing a generated symbol. Render every optional part
+        # of the runtime and check the set still covers exactly the names bound
+        # at module scope, so adding a helper cannot silently drift out of it.
+        source = black.format_str(
+            "\n".join(
+                [
+                    render_imports("both", has_events=True),
+                    render_scval_helpers(),
+                    render_event_helpers(),
+                ]
+            ),
+            mode=black.Mode(),
+        )
+        emitted = _top_level_bindings(ast.parse(source))
+        emitted.discard("annotations")  # __future__ import, not a real binding
+        # Emitted elsewhere, from templates that need a spec to render.
+        emitted |= {"Client", "ClientAsync", "_EVENTS", "parse_event"}
+        assert emitted == set(_GENERATED_MODULE_NAMES)
+
+    def test_generated_module_binds_each_name_once(self):
+        # A UDT or event whose name collides with a generated symbol must be
+        # renamed, not emitted a second time and silently shadowed.
+        specs = [
+            _struct(b"Payload", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+            _struct(b"other::Payload", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+            _struct(b"parse_event", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+            _event(
+                b"payload",
+                [b"payload"],
+                [_data_param(b"payload", _udt_type(b"Payload"))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        source = black.format_str(
+            generate_binding(specs, client_type="both"), mode=black.Mode()
+        )
+        tree = ast.parse(source)
+        names = [
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef))
+        ] + [
+            target.id
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        ]
+        assert len(names) == len(set(names)), "generated module binds a name twice"
+
+
+class TestGeneratedIdentifierSafety:
+    def test_invalid_event_and_param_names_are_sanitized_and_unique(self):
+        specs = [
+            _event(
+                b"1odd-event",
+                [b"odd"],
+                [
+                    _topic_param(b"bad-name", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                    _data_param(b"from", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_VEC,
+            ),
+            _event(
+                b"duplicates",
+                [b"duplicates"],
+                [
+                    _data_param(b"from", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                    _data_param(b"from_", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                    _data_param(b"self", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                    _data_param(b"cls", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_VEC,
+            ),
+        ]
+        ns = _load_bindings(specs)
+        odd_event = _contract_event(
+            [scval.to_symbol("odd"), scval.to_uint32(1)],
+            scval.to_vec([scval.to_uint32(2)]),
+        )
+        parsed = ns["_1oddEvent"].parse(odd_event)
+        assert parsed.bad_name == 1
+        assert parsed.from_ == 2
+
+        duplicate_event = _contract_event(
+            [scval.to_symbol("duplicates")],
+            scval.to_vec([scval.to_uint32(i) for i in range(4)]),
+        )
+        parsed = ns["DuplicatesEvent"].parse(duplicate_event)
+        assert parsed.from_ == 0
+        assert parsed.from__ == 1
+        assert parsed.self_ == 2
+        assert parsed.cls_ == 3
+
+    def test_dunder_params_are_safe_attributes(self):
+        specs = [
+            _event(
+                b"dunders",
+                [b"dunders"],
+                [
+                    _data_param(name, _type(xdr.SCSpecType.SC_SPEC_TYPE_U32))
+                    for name in (b"__class__", b"__dict__", b"__weakref__")
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_VEC,
+            )
+        ]
+        ns = _load_bindings(specs)
+        parsed = ns["DundersEvent"].parse(
+            _contract_event(
+                [scval.to_symbol("dunders")],
+                scval.to_vec([scval.to_uint32(i) for i in range(3)]),
+            )
+        )
+        assert parsed.__class___ == 0
+        assert parsed.__dict___ == 1
+        assert parsed.__weakref___ == 2
+
+    def test_nfkc_equivalent_names_are_disambiguated(self):
+        kelvin_sign = "K".encode()
+        specs = [
+            _event(
+                b"unicode",
+                [b"unicode"],
+                [
+                    _data_param(b"K", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                    _data_param(kelvin_sign, _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_VEC,
+            )
+        ]
+        ns = _load_bindings(specs)
+        parsed = ns["UnicodeEvent"].parse(
+            _contract_event(
+                [scval.to_symbol("unicode")],
+                scval.to_vec([scval.to_uint32(1), scval.to_uint32(2)]),
+            )
+        )
+        assert parsed.K == 1
+        assert parsed.K_ == 2
+
+    def test_event_spec_strings_cannot_inject_generated_code(self):
+        entry = _event(
+            b"safe",
+            [b"safe"],
+            [],
+            xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+        )
+        malicious_doc = b"x'''\n    INJECTED = True\n    #"
+        entry.event_v0.doc = malicious_doc
+        ns = _load_bindings([entry])
+        assert ns["SafeEvent"].__doc__ == malicious_doc.decode()
+        assert not hasattr(ns["SafeEvent"], "INJECTED")
+        assert "INJECTED" not in ns
+
+    def test_invalid_single_value_declaration_is_rejected(self):
+        specs = [
+            _event(
+                b"invalid",
+                [b"invalid"],
+                [
+                    _data_param(b"a", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                    _data_param(b"b", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            )
+        ]
+        with pytest.raises(ValueError, match="at most one data parameter"):
+            generate_binding(specs, client_type="none")
+
+
+class TestDuplicateEventDeclarations:
+    def setup_method(self):
+        self.specs = [
+            _event(
+                b"changed",
+                [b"first"],
+                [_topic_param(b"account", _type(xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+            _event(
+                b"changed",
+                [b"second"],
+                [_topic_param(b"index", _type(xdr.SCSpecType.SC_SPEC_TYPE_U32))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        # Both declarations have no data params, so SEP-48 requires SCV_VOID.
+        self.ns = _load_bindings(self.specs)
+
+    def test_each_declaration_gets_distinct_parser_and_filter(self):
+        first = _contract_event(
+            [scval.to_symbol("first"), scval.to_address(FROM_ADDRESS)],
+            scval.to_void(),
+        )
+        second = _contract_event(
+            [scval.to_symbol("second"), scval.to_uint32(3)], scval.to_void()
+        )
+        assert isinstance(self.ns["parse_event"](first), self.ns["ChangedEvent"])
+        assert isinstance(self.ns["parse_event"](second), self.ns["ChangedEvent_"])
+        assert self.ns["ChangedEvent"].topic_filter(account=FROM_ADDRESS) == [
+            scval.to_symbol("first").to_xdr(),
+            scval.to_address(FROM_ADDRESS).to_xdr(),
+            "**",
+        ]
+        assert self.ns["ChangedEvent_"].topic_filter(index=3) == [
+            scval.to_symbol("second").to_xdr(),
+            scval.to_uint32(3).to_xdr(),
+            "**",
+        ]
+
+    def test_generation_reports_occurrence_specific_diagnostics(self):
+        source, diagnostics = generate_binding_with_diagnostics(
+            self.specs, client_type="none"
+        )
+        assert "class ChangedEvent:" in source
+        assert "class ChangedEvent_:" in source
+        assert diagnostics == [
+            "Event binding note: 'changed' -> ChangedEvent "
+            "(declaration 1 of 2 with this event name)",
+            "Event binding note: 'changed' -> ChangedEvent_ "
+            "(declaration 2 of 2 with this event name; "
+            "renamed to avoid a generated-name collision)",
+        ]
+
+
+class TestEventDocumentation:
+    def test_parameter_docs_are_preserved_on_generated_class(self):
+        entry = _event(
+            b"documented",
+            [b"documented"],
+            [_topic_param(b"from", _type(xdr.SCSpecType.SC_SPEC_TYPE_ADDRESS))],
+            xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+        )
+        entry.event_v0.doc = b"Emitted when something changes."
+        entry.event_v0.params[0].doc = b"The source account."
+        ns = _load_bindings([entry])
+        assert "Emitted when something changes." in ns["DocumentedEvent"].__doc__
+        assert (
+            "from_ (wire name 'from'): The source account."
+            in ns["DocumentedEvent"].__doc__
+        )
+
+
+class TestPythonCommand:
+    def test_format_failure_aborts_without_writing_binding(self, monkeypatch):
+        specs = [
+            _event(
+                b"paused",
+                [b"paused"],
+                [],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            )
+        ]
+        monkeypatch.setattr(
+            "stellar_contract_bindings.python.get_specs_by_contract_id",
+            lambda contract_id, rpc_url: specs,
+        )
+
+        def fail_format(source, mode):
+            raise black.InvalidInput("generated source is invalid")
+
+        monkeypatch.setattr(
+            "stellar_contract_bindings.python.black.format_str", fail_format
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(
+                command,
+                ["--contract-id", CONTRACT_ID, "--output", "generated"],
+            )
+            assert result.exit_code != 0
+            assert "formatting failed" in result.output
+            assert not (Path("generated") / "bindings.py").exists()
+
+    def test_duplicate_event_diagnostics_are_printed(self, monkeypatch):
+        specs = [
+            _event(
+                b"changed",
+                [b"first"],
+                [],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+            _event(
+                b"changed",
+                [b"second"],
+                [],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        monkeypatch.setattr(
+            "stellar_contract_bindings.python.get_specs_by_contract_id",
+            lambda contract_id, rpc_url: specs,
+        )
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            result = runner.invoke(command, ["--contract-id", CONTRACT_ID])
+            assert result.exit_code == 0, result.output
+            assert "'changed' -> ChangedEvent (declaration 1 of 2" in result.output
+            assert "'changed' -> ChangedEvent_ (declaration 2 of 2" in result.output
+
+
+class TestHashability:
+    def setup_method(self):
+        specs = [
+            _event(
+                b"batch",
+                [b"batch"],
+                [
+                    _data_param(
+                        b"values",
+                        _vec_type(_type(xdr.SCSpecType.SC_SPEC_TYPE_U32)),
+                    )
+                ],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+            _event(
+                b"single",
+                [b"single"],
+                [_data_param(b"amount", _type(xdr.SCSpecType.SC_SPEC_TYPE_I128))],
+                xdr.SCSpecEventDataFormat.SC_SPEC_EVENT_DATA_FORMAT_SINGLE_VALUE,
+            ),
+        ]
+        self.ns = _load_bindings(specs)
+
+    def test_event_with_vec_param_is_unhashable(self):
+        # Like the generated struct and union classes, events always define
+        # __hash__; hashing one that holds a list fails the same way it would
+        # for a struct with a Vec field.
+        event = _contract_event(
+            [scval.to_symbol("batch")],
+            scval.to_vec([scval.to_uint32(1)]),
+        )
+        parsed = self.ns["BatchEvent"].parse(event)
+        with pytest.raises(TypeError):
+            hash(parsed)
+        # Equality still works.
+        assert parsed == self.ns["BatchEvent"].parse(event)
+
+    def test_event_with_hashable_params_is_hashable(self):
+        event = _contract_event([scval.to_symbol("single")], scval.to_int128(1))
+        parsed = self.ns["SingleEvent"].parse(event)
+        assert hash(parsed) == hash(self.ns["SingleEvent"].parse(event))
+
+
+class TestStellarAssetContractSpec:
+    """End-to-end over the embedded Stellar Asset Contract spec, which declares
+    events using all shapes emitted by real contracts."""
+
+    def setup_method(self):
+        self.ns = _load_bindings(get_token_sc_spec_entry())
+
+    def test_transfer_with_muxed_variants_disambiguate(self):
+        base_topics = [
+            scval.to_symbol("transfer"),
+            scval.to_address(FROM_ADDRESS),
+            scval.to_address(TO_ADDRESS),
+        ]
+        map_event = _contract_event(
+            base_topics,
+            scval.to_struct(
+                {
+                    "to_muxed_id": scval.to_uint64(123),
+                    "amount": scval.to_int128(42),
+                }
+            ),
+        )
+        parsed = self.ns["parse_event"](map_event)
+        assert isinstance(parsed, self.ns["TransferEvent"])
+        assert parsed.to_muxed_id == 123
+        assert parsed.amount == 42
+
+        map_without_muxed_id = _contract_event(
+            base_topics,
+            scval.to_struct({"amount": scval.to_int128(42)}),
+        )
+        parsed = self.ns["parse_event"](map_without_muxed_id)
+        assert isinstance(parsed, self.ns["TransferEvent"])
+        assert parsed.to_muxed_id is None
+        assert parsed.amount == 42
+
+        legacy_event = _contract_event(base_topics, scval.to_int128(42))
+        parsed = self.ns["parse_event"](legacy_event)
+        assert isinstance(parsed, self.ns["TransferWithAmountOnlyEvent"])
+        assert parsed.amount == 42
+
+    def test_burn(self):
+        event = _contract_event(
+            [scval.to_symbol("burn"), scval.to_address(FROM_ADDRESS)],
+            scval.to_int128(7),
+        )
+        parsed = self.ns["parse_event"](event)
+        assert isinstance(parsed, self.ns["BurnEvent"])
+        assert parsed.from_ == Address(FROM_ADDRESS)
+        assert parsed.amount == 7
+
+    def test_mainnet_shaped_transfer(self):
+        # Real mainnet XLM SAC transfer events carry a trailing SEP-11 asset
+        # string topic that the stellar-asset-spec declarations omit, and use
+        # the legacy bare-i128 data format.
+        event = _contract_event(
+            [
+                scval.to_symbol("transfer"),
+                scval.to_address(FROM_ADDRESS),
+                scval.to_address(TO_ADDRESS),
+                scval.to_string("native"),
+            ],
+            scval.to_int128(601428),
+        )
+        parsed = self.ns["parse_event"](event)
+        assert isinstance(parsed, self.ns["TransferWithAmountOnlyEvent"])
+        assert parsed.from_ == Address(FROM_ADDRESS)
+        assert parsed.to == Address(TO_ADDRESS)
+        assert parsed.amount == 601428
+
+    def test_topic_filter_reaches_events_with_extra_topics(self):
+        # The declaration has 3 topics but mainnet SAC transfers carry a 4th
+        # (the SEP-11 asset string). Without the trailing "**" the RPC matches
+        # on the exact topic count and would never return them.
+        topics = self.ns["TransferEvent"].topic_filter(to=TO_ADDRESS)
+        assert topics[-1] == "**"
+        assert topics[:-1] == [
+            scval.to_symbol("transfer").to_xdr(),
+            "*",
+            scval.to_address(TO_ADDRESS).to_xdr(),
+        ]
+        # "**" is excluded from the RPC's four-segment limit.
+        assert len(topics) - 1 <= 4


### PR DESCRIPTION
Generates a typed Python class for every event a contract declares in its SEP-48 spec, plus an `Event` union alias, a `parse_event` dispatcher, and a `topic_filter()` builder for RPC `getEvents` queries. Event entries in contract specs are new in Protocol 23; until now the Python generator ignored them entirely.

The examples below use the native XLM Stellar Asset Contract on mainnet, `CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA`, whose embedded spec declares 13 events spanning all three data formats (`SINGLE_VALUE`, `VEC`, `MAP`).

## Usage

```shell
stellar-contract-bindings python \
  --contract-id CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA \
  --rpc-url https://rpc.lightsail.network \
  --output ./bindings
```

Alongside the usual `Client` and `ClientAsync`, the generated `bindings.py` now contains one class per declared event, `ApproveEvent`, `BurnEvent`, `ClawbackEvent`, `SetAdminEvent`, `SetAuthorizedEvent`, and the transfer/mint families (`TransferEvent`, `TransferWithAmountOnlyEvent`, `TransferWithMuxedStringEvent`, `TransferWithMuxedBytesEvent`, and their `Mint` counterparts), an `Event` union alias over all of them, and `parse_event`.

### Reading events from RPC

`topic_filter()` builds one topics row. Omitted topic parameters become `"*"` wildcards, so callers specify only the fields they want to filter on.

```python
from stellar_sdk import SorobanServer
from stellar_sdk.soroban_rpc import EventFilter, EventFilterType

from bindings import (
    TransferEvent,
    TransferWithAmountOnlyEvent,
    TransferWithMuxedBytesEvent,
    TransferWithMuxedStringEvent,
    parse_event,
)

CONTRACT_ID = "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA"
TRANSFER_EVENTS = (
    TransferWithAmountOnlyEvent,
    TransferEvent,
    TransferWithMuxedStringEvent,
    TransferWithMuxedBytesEvent,
)

with SorobanServer("https://rpc.lightsail.network") as server:
    start_ledger = server.get_latest_ledger().sequence - 200
    response = server.get_events(
        start_ledger,
        filters=[
            EventFilter(
                type=EventFilterType.CONTRACT,
                contractIds=[CONTRACT_ID],
                # Every transfer. Pass to=<address> to select one recipient.
                topics=[TransferEvent.topic_filter()],
            )
        ],
        limit=5,
    )

    for event_info in response.events:
        event = parse_event(event_info)
        if isinstance(event, TRANSFER_EVENTS):
            print(type(event).__name__, event.from_, "->", event.to, event.amount)
```

Attributes are typed from the spec: `from_` and `to` are `Address`, `amount` is `int`, and `to_muxed_id` on the map-format variants is `Optional[int]`. Names that are not valid Python identifiers are sanitized, the Python keyword `from` becomes `from_`, while the original spec name is still used for wire-format map keys. Where the spec supplies a parameter docstring, the generated class documentation notes the wire name alongside the renamed attribute.

### Reading events from transaction meta or raw values

The same classes accept `xdr.ContractEvent` values from transaction meta and raw `(topics, data)` pairs. Raw entries may be `xdr.SCVal` objects, Base64 XDR strings, or binary XDR bytes.

```python
from bindings import TransferEvent, parse_event

event = parse_event(contract_event)              # xdr.ContractEvent
event = parse_event((topic_scvals, data_scval))  # raw SCVal values
event = parse_event((topic_xdr_strings, data_xdr_string))
event = parse_event((topic_xdr_bytes, data_xdr_bytes))

# Parse one known event type directly; ValueError is raised on a mismatch.
transfer = TransferEvent.parse(contract_event)
```

### Calling contract functions

Unchanged, but included since the example contract is a token:

```python
from stellar_sdk import Network

from bindings import Client

client = Client(
    "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
    "https://rpc.lightsail.network",
    Network.PUBLIC_NETWORK_PASSPHRASE,
)
print(client.symbol().result(), client.decimals().result())  # b'native' 7
```

## Behaviour worth knowing

**Filters end with `"**"`.** On-chain events can carry topics their declaration omits, SAC events append the SEP-11 asset string, so a mainnet `transfer` has four topics where the embedded declaration has three. RPC topic filters otherwise match on the exact topic count, so `topic_filter()` appends a trailing `"**"` wildcard that matches zero or more additional topics:

```text
with **     ['AAAADwAAAAh0cmFuc2Zlcg==', '*', '*', '**'] -> four-topic events match
without **  ['AAAADwAAAAh0cmFuc2Zlcg==', '*', '*']       -> no four-topic events match
```

`"**"` was added in stellar-rpc v23.0.0, must be the final segment, and does not count toward the RPC's four-segment topic-filter limit.

**Matching is tolerant where compatibility requires it, strict about the declared shape.** Extra trailing topics are ignored, so mainnet SAC events stay compatible with the embedded declaration. Static prefix topics may be encoded as either `SCV_SYMBOL` or `SCV_STRING`, per SEP-48 matching rules. A missing top-level `Option<T>` entry in `MAP` data becomes `None`, covering SEP-41 SAC events where `to_muxed_id` may be absent, but a missing *required* map entry is rejected rather than silently parsed as `None`. Extra map entries are ignored so a compatible extension does not break older bindings. A zero-parameter `SINGLE_VALUE` event must carry `SCV_VOID`, and `VEC` data must contain at least the number of values the spec declares.

**Ambiguity is resolved most-specific-first.** Several declarations can share a static topic prefix, so candidates are tried in descending order of declared topic count, which prevents a shorter declaration from consuming an event belonging to a longer one. Ties retain spec order, and a candidate whose data fails to decode moves dispatch on to the next one. The SAC transfer variants all declare the same three topics, so it is their data shape rather than topic specificity that disambiguates them: bare `i128` data parses as `TransferWithAmountOnlyEvent`, while map-form data parses as `TransferEvent` or the matching muxed-address variant.

**Unrecognised events are not errors.** `parse_event` returns `None`, without logging, when no declared event matches the topics; malformed input that cannot be normalized from XDR also returns `None`. If the topics *do* match one or more declarations but none of their data shapes can be parsed, the on-chain format has drifted from the spec the bindings were generated from, that logs a warning by default, or raises `UnparsedEventError` when called with `raise_on_unparsed=True`. The error's `failures` attribute holds each candidate class paired with its parsing exception.

```python
event = parse_event(event_info, raise_on_unparsed=True)
```

## Changes to non-event generation

Supporting events required four fixes to the existing generator, which apply to all generated bindings:

- **Module-qualified UDT names.** Spec names such as `pkg::mod::Type` previously produced invalid Python identifiers. An unambiguous type now uses its bare name (`Type`); when several modules declare the same bare name, the module path is flattened (`pkg_a_Type`, `pkg_b_Type`), with a numeric suffix added only if another generated name still conflicts. References resolve to the same name, including nested UDT fields and event parameters. Event class names share this namespace with UDTs, imports, and runtime helpers; collisions are resolved deterministically and the CLI reports any event whose class name had to change.
- **`SC_SPEC_TYPE_ERROR`** raised `NotImplementedError`, and now maps to `xdr.SCError` and round-trips `SCV_ERROR` values.
- **Value-level `SC_SPEC_TYPE_RESULT`**, event fields and results nested inside containers, maps to `Union[OkType, ErrorType]` and decodes either arm. A top-level contract function output declared `Result<T, E>` continues to generate `AssembledTransaction[T]` exactly as before, so no existing signature changes: returning `Err` traps the invocation and the SDK surfaces that as an exception, so an `SCV_ERROR` value can never reach the successful result decoder.
- **`SC_SPEC_TYPE_VOID` decoding** called `scval.from_void()` without its required argument; it now passes the value through.

Event-only imports and helpers are emitted only when a contract declares event entries, so bindings for a contract without events gain no event runtime, though the fixes above still apply wherever their spec types appear.
