### PR TITLE
fix(flutter,php,swift,kmp): escape spec text in generated comments and string literals

### DIFF
--- a/stellar_contract_bindings/flutter.py
+++ b/stellar_contract_bindings/flutter.py
@@ -129,6 +129,48 @@ def camel_to_snake(text: str) -> str:
             result += char
     return result
 
+
+def dart_doc(doc: bytes | None, fallback: str, indent: str = "") -> str:
+    """Render spec doc text as a Dart doc comment.
+
+    Doc text comes from the contract spec, so a contract can publish a doc
+    carrying newlines. Emitted after a single ``///`` its later lines would
+    land in the class body as source, so every line carries its own marker.
+    """
+    text = doc.decode() if doc else fallback
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    # rstrip leaves a bare marker for an empty or whitespace-only line.
+    return "\n".join(f"{indent}/// {line}".rstrip() for line in lines)
+
+
+def dart_string(text: str) -> str:
+    """Escape spec-derived text for a single-quoted Dart string literal.
+
+    A single quote ends the literal and a line terminator breaks it, letting
+    the rest of the text through as source; a dollar sign starts an
+    interpolation that runs code, and a backslash consumes the character after
+    it, the closing quote included. The remaining control characters go in as
+    ``\\u{...}`` so that the literal stays printable source. Every escape used
+    here preserves the original characters, so the on-chain name the literal
+    carries is unchanged.
+
+    Every spec-derived Dart literal the templates emit is single quoted, so
+    this is the only Dart escaper.
+    """
+    escaped = (
+        text.replace("\\", "\\\\")
+        .replace("'", "\\'")
+        .replace("$", "\\$")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return "".join(
+        char if char >= " " and char != "\x7f" else f"\\u{{{ord(char):x}}}"
+        for char in escaped
+    )
+
+
 def to_dart_type(td: xdr.SCSpecTypeDef, nullable: bool = False, class_name: str = "") -> str:
     t = td.type
     nullable_suffix = "?" if nullable else ""
@@ -440,7 +482,7 @@ import 'package:stellar_flutter_sdk/stellar_flutter_sdk.dart';
 def render_enum(entry: xdr.SCSpecUDTEnumV0, class_name: str):
     type_name = prefixed_type_name(entry.name.decode(), class_name)
     template = """
-/// {{ entry.doc.decode() if entry.doc else type_name + ' enum' }}
+{{ dart_doc(entry.doc, type_name + ' enum') }}
 enum {{ type_name }} {
   {%- for case in entry.cases %}
   {{ snake_to_camel(case.name.decode(), False) }}({{ case.value.uint32 }}){% if loop.last %};{% else %},{% endif %}
@@ -453,7 +495,7 @@ enum {{ type_name }} {
   factory {{ type_name }}.fromValue(int value) {
     return {{ type_name }}.values.firstWhere(
       (e) => e.value == value,
-      orElse: () => throw ArgumentError('Unknown {{ type_name }} value: $value'),
+      orElse: () => throw ArgumentError('Unknown {{ dart_string(type_name) }} value: $value'),
     );
   }
   
@@ -467,7 +509,11 @@ enum {{ type_name }} {
 }
 """
     rendered_code = Template(template).render(
-        entry=entry, type_name=type_name, snake_to_camel=snake_to_camel
+        entry=entry,
+        type_name=type_name,
+        snake_to_camel=snake_to_camel,
+        dart_doc=dart_doc,
+        dart_string=dart_string,
     )
     return rendered_code
 
@@ -475,7 +521,7 @@ enum {{ type_name }} {
 def render_error_enum(entry: xdr.SCSpecUDTErrorEnumV0, class_name: str):
     type_name = prefixed_type_name(entry.name.decode(), class_name)
     template = """
-/// {{ entry.doc.decode() if entry.doc else type_name + ' error enum' }}
+{{ dart_doc(entry.doc, type_name + ' error enum') }}
 enum {{ type_name }} {
   {%- for case in entry.cases %}
   {{ snake_to_camel(case.name.decode(), False) }}({{ case.value.uint32 }}){% if loop.last %};{% else %},{% endif %}
@@ -488,7 +534,7 @@ enum {{ type_name }} {
   factory {{ type_name }}.fromValue(int value) {
     return {{ type_name }}.values.firstWhere(
       (e) => e.value == value,
-      orElse: () => throw ArgumentError('Unknown {{ type_name }} value: $value'),
+      orElse: () => throw ArgumentError('Unknown {{ dart_string(type_name) }} value: $value'),
     );
   }
   
@@ -502,7 +548,11 @@ enum {{ type_name }} {
 }
 """
     rendered_code = Template(template).render(
-        entry=entry, type_name=type_name, snake_to_camel=snake_to_camel
+        entry=entry,
+        type_name=type_name,
+        snake_to_camel=snake_to_camel,
+        dart_doc=dart_doc,
+        dart_string=dart_string,
     )
     return rendered_code
 
@@ -525,7 +575,7 @@ def render_struct(entry: xdr.SCSpecUDTStructV0, class_name: str):
     # contract spec already provides sorted ascending by field name, so the map
     # entries need no explicit sort (unlike map arguments).
     template = """
-/// {{ entry.doc.decode() if entry.doc else type_name + ' struct' }}
+{{ dart_doc(entry.doc, type_name + ' struct') }}
 class {{ type_name }} {
   {%- for field in entry.fields %}
   final {{ to_dart_type(field.type) }} {{ escape_identifier(field.name.decode()) }};
@@ -541,7 +591,7 @@ class {{ type_name }} {
     final fields = <XdrSCMapEntry>[];
     {%- for field in entry.fields %}
     fields.add(XdrSCMapEntry(
-      XdrSCVal.forSymbol('{{ field.name_r.decode() if field.name_r else field.name.decode() }}'),
+      XdrSCVal.forSymbol('{{ dart_string(field.name_r.decode() if field.name_r else field.name.decode()) }}'),
       {{ to_scval(field.type, escape_identifier(field.name.decode())) }},
     ));
     {%- endfor %}
@@ -557,7 +607,7 @@ class {{ type_name }} {
     
     return {{ type_name }}(
       {%- for field in entry.fields %}
-      {{ escape_identifier(field.name.decode()) }}: {{ from_scval(field.type, 'fieldsMap["' ~ (field.name_r.decode() if field.name_r else field.name.decode()) ~ '"]!') }},
+      {{ escape_identifier(field.name.decode()) }}: {{ from_scval(field.type, "fieldsMap['" ~ dart_string(field.name_r.decode() if field.name_r else field.name.decode()) ~ "']!") }},
       {%- endfor %}
     );
   }
@@ -586,6 +636,8 @@ class {{ type_name }} {
         from_scval=from_scval_bound,
         snake_to_camel=snake_to_camel,
         escape_identifier=escape_identifier,
+        dart_doc=dart_doc,
+        dart_string=dart_string,
     )
     return rendered_code
 
@@ -604,7 +656,7 @@ def render_tuple_struct(entry: xdr.SCSpecUDTStructV0, class_name: str):
         return from_scval(td, name, class_name)
     
     template = """
-/// {{ entry.doc.decode() if entry.doc else type_name + ' tuple struct' }}
+{{ dart_doc(entry.doc, type_name + ' tuple struct') }}
 class {{ type_name }} {
   final ({% for f in entry.fields %}{{ to_dart_type(f.type) }}{% if not loop.last %}, {% endif %}{% endfor %}) value;
 
@@ -641,7 +693,8 @@ class {{ type_name }} {
         type_name=type_name,
         to_dart_type=to_dart_type_bound,
         to_scval=to_scval_bound,
-        from_scval=from_scval_bound
+        from_scval=from_scval_bound,
+        dart_doc=dart_doc,
     )
     return rendered_code
 
@@ -664,9 +717,9 @@ def render_union(entry: xdr.SCSpecUDTUnionV0, class_name: str):
 enum {{ type_name }}Kind {
   {%- for case in entry.cases %}
   {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 %}
-  {{ snake_to_camel(case.void_case.name.decode(), False) }}('{{ case.void_case.name_r.decode() if case.void_case.name_r else case.void_case.name.decode() }}'){% if loop.last %};{% else %},{% endif %}
+  {{ snake_to_camel(case.void_case.name.decode(), False) }}('{{ dart_string(case.void_case.name_r.decode() if case.void_case.name_r else case.void_case.name.decode()) }}'){% if loop.last %};{% else %},{% endif %}
   {%- else %}
-  {{ snake_to_camel(case.tuple_case.name.decode(), False) }}('{{ case.tuple_case.name_r.decode() if case.tuple_case.name_r else case.tuple_case.name.decode() }}'){% if loop.last %};{% else %},{% endif %}
+  {{ snake_to_camel(case.tuple_case.name.decode(), False) }}('{{ dart_string(case.tuple_case.name_r.decode() if case.tuple_case.name_r else case.tuple_case.name.decode()) }}'){% if loop.last %};{% else %},{% endif %}
   {%- endif %}
   {%- endfor %}
 
@@ -677,17 +730,21 @@ enum {{ type_name }}Kind {
   factory {{ type_name }}Kind.fromValue(String value) {
     return {{ type_name }}Kind.values.firstWhere(
       (e) => e.value == value,
-      orElse: () => throw ArgumentError('Unknown {{ type_name }}Kind value: $value'),
+      orElse: () => throw ArgumentError('Unknown {{ dart_string(type_name) }}Kind value: $value'),
     );
   }
 }
 """
     kind_enum_rendered_code = Template(kind_enum_template).render(
-        entry=entry, type_name=type_name, xdr=xdr, snake_to_camel=snake_to_camel
+        entry=entry,
+        type_name=type_name,
+        xdr=xdr,
+        snake_to_camel=snake_to_camel,
+        dart_string=dart_string,
     )
 
     template = """
-/// {{ entry.doc.decode() if entry.doc else type_name + ' union' }}
+{{ dart_doc(entry.doc, type_name + ' union') }}
 class {{ type_name }} {
   final {{ type_name }}Kind kind;
   {%- for case in entry.cases %}
@@ -833,6 +890,7 @@ class {{ type_name }} {
         snake_to_camel=snake_to_camel,
         escape_identifier=escape_identifier,
         enumerate=enumerate,
+        dart_doc=dart_doc,
     )
     return kind_enum_rendered_code + "\n" + union_rendered_code
 
@@ -878,7 +936,7 @@ class {{ class_name }} {
       
   {%- for entry in entries %}
   
-  /// {{ entry.doc.decode() if entry.doc else 'Invokes the ' + entry.name.sc_symbol.decode() + ' method' }}
+{{ dart_doc(entry.doc, 'Invokes the ' + entry.name.sc_symbol.decode() + ' method', '  ') }}
   {%- if parse_result_type(entry.outputs) == 'void' %}
   Future<void> {{ escape_identifier(entry.name.sc_symbol.decode()) }}({
   {%- else %}
@@ -907,7 +965,7 @@ class {{ class_name }} {
     );
 
     {% if parse_result_type(entry.outputs) == 'void' %}await{% else %}final result = await{% endif %} _client.invokeMethod(
-      name: '{{ entry.name.sc_symbol_r.decode() if entry.name.sc_symbol_r else entry.name.sc_symbol.decode() }}',
+      name: '{{ dart_string(entry.name.sc_symbol_r.decode() if entry.name.sc_symbol_r else entry.name.sc_symbol.decode()) }}',
       args: args,
       force: force,
       methodOptions: methodOptions,
@@ -918,7 +976,7 @@ class {{ class_name }} {
     {%- endif %}
   }
   
-  /// Builds an AssembledTransaction for the {{ entry.name.sc_symbol.decode() }} method.
+{{ dart_doc(None, 'Builds an AssembledTransaction for the ' + entry.name.sc_symbol.decode() + ' method.', '  ') }}
   /// This is useful if you need to manipulate the transaction before signing and sending.
   Future<AssembledTransaction> build{{ snake_to_camel(entry.name.sc_symbol.decode(), False) }}Tx({
     {%- for param in entry.inputs %}
@@ -933,7 +991,7 @@ class {{ class_name }} {
     ];
     
     return await _client.buildInvokeMethodTx(
-      name: '{{ entry.name.sc_symbol_r.decode() if entry.name.sc_symbol_r else entry.name.sc_symbol.decode() }}',
+      name: '{{ dart_string(entry.name.sc_symbol_r.decode() if entry.name.sc_symbol_r else entry.name.sc_symbol.decode()) }}',
       args: args,
       methodOptions: methodOptions,
     );
@@ -974,6 +1032,8 @@ class {{ class_name }} {
         snake_to_camel=snake_to_camel,
         escape_identifier=escape_identifier,
         class_name=class_name,
+        dart_doc=dart_doc,
+        dart_string=dart_string,
     )
     return client_rendered_code
 

--- a/stellar_contract_bindings/kmp.py
+++ b/stellar_contract_bindings/kmp.py
@@ -101,6 +101,59 @@ def escape_keyword(name: str) -> str:
     return name
 
 
+def kotlin_doc(
+    doc: bytes | None, fallback: str, indent: str = "", prefix: str = ""
+) -> str:
+    """Render spec doc text as the body of a KDoc block.
+
+    Doc text comes from the contract spec, so a contract can publish a doc
+    carrying newlines, which would leave the later lines without their ``*``,
+    or one of the sequences that delimit a block comment. Kotlin nests block
+    comments, so a ``/*`` in the text opens one that the block's own ``*/``
+    then closes, leaving the code that follows inside a comment; a ``*/``
+    closes the block early and lets the rest of the text through as source.
+    Every line gets its own marker and both delimiters are broken up.
+
+    ``prefix`` introduces the first line as a tag such as ``@param x``; the
+    lines that follow it are indented two spaces so that they continue the
+    same tag. It is spec-derived too, so it goes through the same escaping and
+    line splitting rather than around them.
+    """
+    text = prefix + (doc.decode() if doc else fallback)
+    text = text.replace("*/", "*\\/").replace("/*", "/\\*")
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    continuation = "  " if prefix else ""
+    # rstrip leaves a bare marker for an empty or whitespace-only line.
+    rendered = [f"{indent} * {lines[0]}".rstrip()]
+    rendered += [f"{indent} * {continuation}{line}".rstrip() for line in lines[1:]]
+    return "\n".join(rendered)
+
+
+def kotlin_string(text: str) -> str:
+    """Escape spec-derived text for a Kotlin string literal.
+
+    A double quote ends the literal and a line terminator breaks it, letting
+    the rest of the text through as source; a dollar sign starts a template
+    expression that runs code, and a backslash consumes the character after it,
+    the closing quote included. The remaining control characters go in as
+    ``\\uXXXX`` so that the literal stays printable source. Every escape used
+    here preserves the original characters, so the on-chain name the literal
+    carries is unchanged.
+    """
+    escaped = (
+        text.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("$", "\\$")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return "".join(
+        char if char >= " " and char != "\x7f" else f"\\u{ord(char):04x}"
+        for char in escaped
+    )
+
+
 def prefixed_type_name(type_name: str, class_name: str) -> str:
     """Prefix a UDT type name with the class name to avoid collisions.
 
@@ -600,7 +653,7 @@ def render_enum(entry: xdr.SCSpecUDTEnumV0, class_name: str) -> str:
     type_name = prefixed_type_name(entry.name.decode(), class_name)
     template = """
 /**
- * {{ entry.doc.decode() if entry.doc else 'Generated enum ' + type_name }}
+{{ kotlin_doc(entry.doc, 'Generated enum ' + type_name) }}
  */
 enum class {{ type_name }}(val value: UInt) {
     {%- for case in entry.cases %}
@@ -612,14 +665,18 @@ enum class {{ type_name }}(val value: UInt) {
     companion object {
         fun fromValue(value: UInt): {{ type_name }} =
             {{ type_name }}.entries.firstOrNull { it.value == value }
-                ?: throw IllegalArgumentException("Unknown {{ type_name }} value: $value")
+                ?: throw IllegalArgumentException("Unknown {{ kotlin_string(type_name) }} value: $value")
 
         fun fromSCVal(scVal: SCValXdr): {{ type_name }} = fromValue(Scv.fromUint32(scVal))
     }
 }
 """
     return Template(template).render(
-        entry=entry, type_name=type_name, escape_keyword=escape_keyword
+        entry=entry,
+        type_name=type_name,
+        escape_keyword=escape_keyword,
+        kotlin_doc=kotlin_doc,
+        kotlin_string=kotlin_string,
     )
 
 
@@ -632,7 +689,7 @@ def render_error_enum(entry: xdr.SCSpecUDTErrorEnumV0, class_name: str) -> str:
     type_name = prefixed_type_name(entry.name.decode(), class_name)
     template = """
 /**
- * {{ entry.doc.decode() if entry.doc else 'Generated error enum ' + type_name }}
+{{ kotlin_doc(entry.doc, 'Generated error enum ' + type_name) }}
  */
 enum class {{ type_name }}(val value: UInt) {
     {%- for case in entry.cases %}
@@ -644,14 +701,18 @@ enum class {{ type_name }}(val value: UInt) {
     companion object {
         fun fromValue(value: UInt): {{ type_name }} =
             {{ type_name }}.entries.firstOrNull { it.value == value }
-                ?: throw IllegalArgumentException("Unknown {{ type_name }} value: $value")
+                ?: throw IllegalArgumentException("Unknown {{ kotlin_string(type_name) }} value: $value")
 
         fun fromSCVal(scVal: SCValXdr): {{ type_name }} = fromValue(Scv.fromUint32(scVal))
     }
 }
 """
     return Template(template).render(
-        entry=entry, type_name=type_name, escape_keyword=escape_keyword
+        entry=entry,
+        type_name=type_name,
+        escape_keyword=escape_keyword,
+        kotlin_doc=kotlin_doc,
+        kotlin_string=kotlin_string,
     )
 
 
@@ -676,7 +737,7 @@ def render_struct(entry: xdr.SCSpecUDTStructV0, class_name: str) -> str:
     # entries need no explicit sort (unlike map arguments).
     template = """
 /**
- * {{ entry.doc.decode() if entry.doc else 'Generated struct ' + type_name }}
+{{ kotlin_doc(entry.doc, 'Generated struct ' + type_name) }}
  */
 data class {{ type_name }}(
     {%- for field in entry.fields %}
@@ -686,7 +747,7 @@ data class {{ type_name }}(
     fun toSCVal(): SCValXdr {
         val map = LinkedHashMap<SCValXdr, SCValXdr>()
         {%- for field in entry.fields %}
-        map[Scv.toSymbol("{{ field.name.decode() }}")] = {{ to_scval(field.type, escape_keyword(field.name.decode())) }}
+        map[Scv.toSymbol("{{ kotlin_string(field.name.decode()) }}")] = {{ to_scval(field.type, escape_keyword(field.name.decode())) }}
         {%- endfor %}
         return Scv.toMap(map)
     }
@@ -696,7 +757,7 @@ data class {{ type_name }}(
             val map = Scv.fromMap(scVal)
             return {{ type_name }}(
                 {%- for field in entry.fields %}
-                {{ escape_keyword(field.name.decode()) }} = {{ from_scval(field.type, 'map[Scv.toSymbol("' ~ field.name.decode() ~ '")]!!') }}{% if not loop.last %},{% endif %}
+                {{ escape_keyword(field.name.decode()) }} = {{ from_scval(field.type, 'map[Scv.toSymbol("' ~ kotlin_string(field.name.decode()) ~ '")]!!') }}{% if not loop.last %},{% endif %}
                 {%- endfor %}
             )
         }
@@ -710,6 +771,8 @@ data class {{ type_name }}(
         to_scval=to_scval_bound,
         from_scval=from_scval_bound,
         escape_keyword=escape_keyword,
+        kotlin_doc=kotlin_doc,
+        kotlin_string=kotlin_string,
     )
 
 
@@ -733,7 +796,7 @@ def render_tuple_struct(entry: xdr.SCSpecUDTStructV0, class_name: str) -> str:
 
     template = """
 /**
- * {{ entry.doc.decode() if entry.doc else 'Generated tuple struct ' + type_name }}
+{{ kotlin_doc(entry.doc, 'Generated tuple struct ' + type_name) }}
  */
 data class {{ type_name }}(
     {%- for field in sorted_fields %}
@@ -767,6 +830,7 @@ data class {{ type_name }}(
         to_kotlin_type=to_kotlin_type_bound,
         to_scval=to_scval_bound,
         from_scval=from_scval_bound,
+        kotlin_doc=kotlin_doc,
     )
 
 
@@ -789,7 +853,7 @@ def render_union(entry: xdr.SCSpecUDTUnionV0, class_name: str) -> str:
 
     template = """
 /**
- * {{ entry.doc.decode() if entry.doc else 'Generated union ' + type_name }}
+{{ kotlin_doc(entry.doc, 'Generated union ' + type_name) }}
  */
 sealed class {{ type_name }} {
     abstract fun toSCVal(): SCValXdr
@@ -797,7 +861,7 @@ sealed class {{ type_name }} {
     {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 %}
 
     object {{ escape_keyword(case.void_case.name.decode()) }} : {{ type_name }}() {
-        override fun toSCVal(): SCValXdr = Scv.toVec(listOf(Scv.toSymbol("{{ case.void_case.name.decode() }}")))
+        override fun toSCVal(): SCValXdr = Scv.toVec(listOf(Scv.toSymbol("{{ kotlin_string(case.void_case.name.decode()) }}")))
     }
     {%- else %}
 
@@ -808,7 +872,7 @@ sealed class {{ type_name }} {
     ) : {{ type_name }}() {
         override fun toSCVal(): SCValXdr = Scv.toVec(
             listOf(
-                Scv.toSymbol("{{ case.tuple_case.name.decode() }}"),
+                Scv.toSymbol("{{ kotlin_string(case.tuple_case.name.decode()) }}"),
                 {%- for i in range(len(case.tuple_case.type)) %}
                 {{ to_scval(case.tuple_case.type[i], 'value' ~ i|string) }}{% if not loop.last %},{% endif %}
                 {%- endfor %}
@@ -824,16 +888,16 @@ sealed class {{ type_name }} {
             return when (val tag = Scv.fromSymbol(elements[0])) {
                 {%- for case in entry.cases %}
                 {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 %}
-                "{{ case.void_case.name.decode() }}" -> {{ escape_keyword(case.void_case.name.decode()) }}
+                "{{ kotlin_string(case.void_case.name.decode()) }}" -> {{ escape_keyword(case.void_case.name.decode()) }}
                 {%- else %}
-                "{{ case.tuple_case.name.decode() }}" -> {{ escape_keyword(case.tuple_case.name.decode()) }}(
+                "{{ kotlin_string(case.tuple_case.name.decode()) }}" -> {{ escape_keyword(case.tuple_case.name.decode()) }}(
                     {%- for i in range(len(case.tuple_case.type)) %}
                     {{ from_scval(case.tuple_case.type[i], 'elements[' ~ (i + 1)|string ~ ']') }}{% if not loop.last %},{% endif %}
                     {%- endfor %}
                 )
                 {%- endif %}
                 {%- endfor %}
-                else -> throw IllegalArgumentException("Unknown {{ type_name }} tag: $tag")
+                else -> throw IllegalArgumentException("Unknown {{ kotlin_string(type_name) }} tag: $tag")
             }
         }
     }
@@ -848,6 +912,8 @@ sealed class {{ type_name }} {
         escape_keyword=escape_keyword,
         xdr=xdr,
         len=len,
+        kotlin_doc=kotlin_doc,
+        kotlin_string=kotlin_string,
     )
 
 
@@ -909,9 +975,9 @@ class {{ class_name }} internal constructor(val client: ContractClient) {
     {%- for entry in entries %}
 
     /**
-     * {{ entry.doc.decode() if entry.doc else 'Invoke the ' + entry.name.sc_symbol.decode() + ' contract function.' }}
+{{ kotlin_doc(entry.doc, 'Invoke the ' + entry.name.sc_symbol.decode() + ' contract function.', '    ') }}
      {%- for param in entry.inputs %}
-     * @param {{ doc_param_name(param) }} {{ param.doc.decode() if param.doc else to_kotlin_type(param.type, class_name) }}
+{{ kotlin_doc(param.doc, to_kotlin_type(param.type, class_name), '    ', '@param ' + doc_param_name(param) + ' ') }}
      {%- endfor %}
      * @param source The source account (G... or M... address)
      * @param signer KeyPair for signing; null for read-only calls
@@ -928,7 +994,7 @@ class {{ class_name }} internal constructor(val client: ContractClient) {
         signer: KeyPair?
     ) {
         client.invoke(
-            functionName = "{{ entry.name.sc_symbol.decode() }}",
+            functionName = "{{ kotlin_string(entry.name.sc_symbol.decode()) }}",
             parameters = listOf({{ encoded_params(entry.inputs) }}),
             source = source,
             signer = signer,
@@ -944,7 +1010,7 @@ class {{ class_name }} internal constructor(val client: ContractClient) {
         signer: KeyPair?
     ): {{ parse_result_type(entry.outputs) }} =
         client.invoke(
-            functionName = "{{ entry.name.sc_symbol.decode() }}",
+            functionName = "{{ kotlin_string(entry.name.sc_symbol.decode()) }}",
             parameters = listOf({{ encoded_params(entry.inputs) }}),
             source = source,
             signer = signer,
@@ -953,12 +1019,12 @@ class {{ class_name }} internal constructor(val client: ContractClient) {
     {%- endif %}
 
     /**
-     * Build an [AssembledTransaction] for the {{ entry.name.sc_symbol.decode() }} contract function.
+{{ kotlin_doc(None, 'Build an [AssembledTransaction] for the ' + entry.name.sc_symbol.decode() + ' contract function.', '    ') }}
      *
      * Use this when you need to inspect or manipulate the transaction (memos, additional
      * signatures, preconditions) before signing and submitting.
      {%- for param in entry.inputs %}
-     * @param {{ doc_param_name(param) }} {{ param.doc.decode() if param.doc else to_kotlin_type(param.type, class_name) }}
+{{ kotlin_doc(param.doc, to_kotlin_type(param.type, class_name), '    ', '@param ' + doc_param_name(param) + ' ') }}
      {%- endfor %}
      * @param source The source account (G... or M... address)
      * @param signer KeyPair for signing; null for read-only calls
@@ -971,7 +1037,7 @@ class {{ class_name }} internal constructor(val client: ContractClient) {
         signer: KeyPair?
     ): AssembledTransaction<{{ parse_result_type(entry.outputs) }}> =
         client.buildInvoke(
-            functionName = "{{ entry.name.sc_symbol.decode() }}",
+            functionName = "{{ kotlin_string(entry.name.sc_symbol.decode()) }}",
             parameters = listOf({{ encoded_params(entry.inputs) }}),
             source = source,
             signer = signer,
@@ -992,6 +1058,8 @@ class {{ class_name }} internal constructor(val client: ContractClient) {
         doc_param_name=doc_param_name,
         escape_keyword=escape_keyword,
         snake_to_camel=snake_to_camel,
+        kotlin_doc=kotlin_doc,
+        kotlin_string=kotlin_string,
         snake_to_pascal=snake_to_pascal,
     )
 

--- a/stellar_contract_bindings/php.py
+++ b/stellar_contract_bindings/php.py
@@ -70,6 +70,54 @@ def escape_keyword(name: str) -> str:
     return name
 
 
+def php_doc(
+    doc: bytes | None,
+    fallback: str,
+    indent: str = "",
+    prefix: str = "",
+    suffix: str = "",
+) -> str:
+    """Render spec doc text as the body of a PHPDoc block.
+
+    Doc text comes from the contract spec, so a contract can publish a doc
+    carrying newlines, which would leave the later lines without their ``*``,
+    or a ``*/``, which would close the block and let the rest of the text
+    through as source. Every line gets its own marker and the sequence that
+    ends a block comment is broken up. A ``/*`` needs no such treatment: PHP
+    block comments do not nest.
+
+    ``prefix`` introduces the first line as a tag such as ``@param int $x``;
+    the lines that follow it are indented two spaces so that they continue the
+    same tag. It carries a spec-derived parameter name, so it goes through the
+    same escaping and line splitting rather than around them. ``suffix``
+    trails the spec text, and is dropped along with it when the entry carries
+    no doc and the fallback is used instead.
+    """
+    text = prefix + (doc.decode() + suffix if doc else fallback)
+    text = text.replace("*/", "*\\/")
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    continuation = "  " if prefix else ""
+    # rstrip leaves a bare marker for an empty or whitespace-only line.
+    rendered = [f"{indent} * {lines[0]}".rstrip()]
+    rendered += [f"{indent} * {continuation}{line}".rstrip() for line in lines[1:]]
+    return "\n".join(rendered)
+
+
+def php_string(text: str) -> str:
+    """Escape spec-derived text for a single-quoted PHP string literal.
+
+    Only a backslash and a single quote are special inside single quotes, and
+    both escapes preserve the original characters, so the on-chain name the
+    literal carries is unchanged. A newline and the control characters are
+    legal inside a PHP string, and single quotes have no escape that would
+    reproduce them, so they are left alone.
+
+    Every spec-derived PHP literal the templates emit is single quoted, so
+    this is the only PHP escaper.
+    """
+    return text.replace("\\", "\\\\").replace("'", "\\'")
+
+
 def prefixed_type_name(type_name: str, class_name: str) -> str:
     """Prefix a type name with the class name to avoid conflicts.
     
@@ -392,11 +440,7 @@ def render_enum(entry: xdr.SCSpecUDTEnumV0, class_name: str):
     type_name = prefixed_type_name(entry.name.decode(), class_name)
     template = """
 /**
-{%- if entry.doc %}
- * {{ entry.doc.decode() }}
-{%- else %}
- * Generated enum {{ type_name }}
-{%- endif %}
+{{ php_doc(entry.doc, 'Generated enum ' + type_name) }}
  */
 enum {{ type_name }}: int
 {
@@ -415,7 +459,7 @@ enum {{ type_name }}: int
     }
 }
 """
-    return Template(template).render(entry=entry, type_name=type_name)
+    return Template(template).render(entry=entry, type_name=type_name, php_doc=php_doc)
 
 
 def render_error_enum(entry: xdr.SCSpecUDTErrorEnumV0, class_name: str):
@@ -423,11 +467,7 @@ def render_error_enum(entry: xdr.SCSpecUDTErrorEnumV0, class_name: str):
     type_name = prefixed_type_name(entry.name.decode(), class_name)
     template = """
 /**
-{%- if entry.doc %}
- * {{ entry.doc.decode() }} (Error enum)
-{%- else %}
- * Generated error enum {{ type_name }}
-{%- endif %}
+{{ php_doc(entry.doc, 'Generated error enum ' + type_name, suffix=' (Error enum)') }}
  */
 enum {{ type_name }}: int
 {
@@ -446,7 +486,7 @@ enum {{ type_name }}: int
     }
 }
 """
-    return Template(template).render(entry=entry, type_name=type_name)
+    return Template(template).render(entry=entry, type_name=type_name, php_doc=php_doc)
 
 
 def render_struct(entry: xdr.SCSpecUDTStructV0, class_name: str):
@@ -457,11 +497,7 @@ def render_struct(entry: xdr.SCSpecUDTStructV0, class_name: str):
     # entries need no explicit sort (unlike map arguments).
     template = """
 /**
-{%- if entry.doc %}
- * {{ entry.doc.decode() }}
-{%- else %}
- * Generated struct {{ type_name }}
-{%- endif %}
+{{ php_doc(entry.doc, 'Generated struct ' + type_name) }}
  */
 class {{ type_name }}
 {
@@ -484,7 +520,7 @@ class {{ type_name }}
         $mapEntries = [];
         {%- for field in entry.fields %}
         $mapEntries[] = new XdrSCMapEntry(
-            XdrSCVal::forSymbol('{{ field.name.decode() }}'),
+            XdrSCVal::forSymbol('{{ php_string(field.name.decode()) }}'),
             {{ to_scval(field.type, '$this->' ~ escape_keyword(field.name.decode()), class_name) }}
         );
         {%- endfor %}
@@ -499,7 +535,7 @@ class {{ type_name }}
         }
         return new self(
             {%- for field in entry.fields %}
-            {{ escape_keyword(field.name.decode()) }}: {{ from_scval(field.type, 'map["' ~ field.name.decode() ~ '"]', class_name) }}{% if not loop.last %},{% endif %}
+            {{ escape_keyword(field.name.decode()) }}: {{ from_scval(field.type, "map['" ~ php_string(field.name.decode()) ~ "']", class_name) }}{% if not loop.last %},{% endif %}
             {%- endfor %}
         );
     }
@@ -512,7 +548,9 @@ class {{ type_name }}
         to_php_type=to_php_type,
         to_scval=to_scval,
         from_scval=from_scval,
-        escape_keyword=escape_keyword
+        escape_keyword=escape_keyword,
+        php_doc=php_doc,
+        php_string=php_string,
     )
 
 
@@ -521,11 +559,7 @@ def render_tuple_struct(entry: xdr.SCSpecUDTStructV0, class_name: str):
     type_name = prefixed_type_name(entry.name.decode(), class_name)
     template = """
 /**
-{%- if entry.doc %}
- * {{ entry.doc.decode() }}
-{%- else %}
- * Generated tuple struct {{ type_name }}
-{%- endif %}
+{{ php_doc(entry.doc, 'Generated tuple struct ' + type_name) }}
  */
 class {{ type_name }}
 {
@@ -565,7 +599,8 @@ class {{ type_name }}
         class_name=class_name,
         to_php_type=to_php_type,
         to_scval=to_scval,
-        from_scval=from_scval
+        from_scval=from_scval,
+        php_doc=php_doc,
     )
 
 
@@ -574,19 +609,15 @@ def render_union(entry: xdr.SCSpecUDTUnionV0, class_name: str):
     type_name = prefixed_type_name(entry.name.decode(), class_name)
     template = """
 /**
-{%- if entry.doc %}
- * {{ entry.doc.decode() }}
-{%- else %}
- * Generated union {{ type_name }}
-{%- endif %}
+{{ php_doc(entry.doc, 'Generated union ' + type_name) }}
  */
 class {{ type_name }}
 {
     public const {% for case in entry.cases -%}
     {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 -%}
-    {{ case.void_case.name.decode().upper() }} = '{{ case.void_case.name.decode() }}'
+    {{ case.void_case.name.decode().upper() }} = '{{ php_string(case.void_case.name.decode()) }}'
     {%- else -%}
-    {{ case.tuple_case.name.decode().upper() }} = '{{ case.tuple_case.name.decode() }}'
+    {{ case.tuple_case.name.decode().upper() }} = '{{ php_string(case.tuple_case.name.decode()) }}'
     {%- endif -%}
     {%- if not loop.last %}, {% else %};{% endif -%}
     {%- endfor %}
@@ -660,13 +691,13 @@ class {{ type_name }}
         switch ($kind) {
             {%- for case in entry.cases %}
             {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 %}
-            case '{{ case.void_case.name.decode() }}':
+            case '{{ php_string(case.void_case.name.decode()) }}':
                 return new self(self::{{ case.void_case.name.decode().upper() }});
             {%- else %}
-            case '{{ case.tuple_case.name.decode() }}':
+            case '{{ php_string(case.tuple_case.name.decode()) }}':
                 {%- if len(case.tuple_case.type) == 1 %}
                 if (count($val->vec) !== 2) {
-                    throw new Exception("Invalid union value for {{ case.tuple_case.name.decode() }}: expected 2 elements");
+                    throw new Exception('Invalid union value for {{ php_string(case.tuple_case.name.decode()) }}: expected 2 elements');
                 }
                 return new self(
                     self::{{ case.tuple_case.name.decode().upper() }},
@@ -674,7 +705,7 @@ class {{ type_name }}
                 );
                 {%- else %}
                 if (count($val->vec) !== {{ len(case.tuple_case.type) + 1 }}) {
-                    throw new Exception("Invalid union value for {{ case.tuple_case.name.decode() }}: expected {{ len(case.tuple_case.type) + 1 }} elements");
+                    throw new Exception('Invalid union value for {{ php_string(case.tuple_case.name.decode()) }}: expected {{ len(case.tuple_case.type) + 1 }} elements');
                 }
                 return new self(
                     self::{{ case.tuple_case.name.decode().upper() }},
@@ -703,7 +734,9 @@ class {{ type_name }}
         xdr=xdr,
         len=len,
         camel_to_snake=camel_to_snake,
-        enumerate=enumerate
+        enumerate=enumerate,
+        php_doc=php_doc,
+        php_string=php_string,
     )
 
 
@@ -772,14 +805,10 @@ class {{ contract_name }}
     {%- for entry in entries %}
 
     /**
-    {%- if entry.doc %}
-     * {{ entry.doc.decode() }}
-    {%- else %}
-     * Invoke the {{ entry.name.sc_symbol.decode() }} method
-    {%- endif %}
+{{ php_doc(entry.doc, 'Invoke the ' + entry.name.sc_symbol.decode() + ' method', '    ') }}
      *
     {%- for param in entry.inputs %}
-     * @param {{ to_php_type(param.type, False, contract_name) }} ${{ escape_keyword(param.name.decode()) }}
+{{ php_doc(param.doc, '', '    ', '@param ' + to_php_type(param.type, False, contract_name) + ' $' + escape_keyword(param.name.decode()) + ' ') }}
     {%- endfor %}
      * @param MethodOptions|null $methodOptions Options for transaction
      * @return {{ parse_result_type(entry.outputs) }}
@@ -799,7 +828,7 @@ class {{ contract_name }}
         ];
         
         {% if parse_result_type(entry.outputs) != "void" %}$result = {% endif %}$this->client->invokeMethod(
-            name: '{{ entry.name.sc_symbol.decode() }}',
+            name: '{{ php_string(entry.name.sc_symbol.decode()) }}',
             args: $args,
             methodOptions: $methodOptions
         );
@@ -809,11 +838,11 @@ class {{ contract_name }}
     }
 
     /**
-     * Build an AssembledTransaction for the {{ entry.name.sc_symbol.decode() }} method.
+{{ php_doc(None, 'Build an AssembledTransaction for the ' + entry.name.sc_symbol.decode() + ' method.', '    ') }}
      * This is useful if you need to manipulate the transaction before signing and sending.
      *
     {%- for param in entry.inputs %}
-     * @param {{ to_php_type(param.type, False, contract_name) }} ${{ escape_keyword(param.name.decode()) }}
+{{ php_doc(param.doc, '', '    ', '@param ' + to_php_type(param.type, False, contract_name) + ' $' + escape_keyword(param.name.decode()) + ' ') }}
     {%- endfor %}
      * @param MethodOptions|null $methodOptions Options for transaction
      * @return AssembledTransaction
@@ -833,7 +862,7 @@ class {{ contract_name }}
         ];
         
         return $this->client->buildInvokeMethodTx(
-            name: '{{ entry.name.sc_symbol.decode() }}',
+            name: '{{ php_string(entry.name.sc_symbol.decode()) }}',
             args: $args,
             methodOptions: $methodOptions
         );
@@ -878,7 +907,9 @@ class {{ contract_name }}
         escape_keyword=escape_keyword,
         snake_to_camel=snake_to_camel,
         snake_to_pascal=snake_to_pascal,
-        len=len
+        len=len,
+        php_doc=php_doc,
+        php_string=php_string,
     )
 
 

--- a/stellar_contract_bindings/swift.py
+++ b/stellar_contract_bindings/swift.py
@@ -66,6 +66,53 @@ def escape_keyword(name: str) -> str:
     return name
 
 
+def swift_doc(
+    doc: bytes | None, fallback: str, indent: str = "", prefix: str = ""
+) -> str:
+    """Render spec doc text as a Swift doc comment.
+
+    Doc text comes from the contract spec, so a contract can publish a doc
+    carrying newlines. Emitted after a single ``///`` its later lines would
+    land in the type body as source, so every line carries its own marker.
+
+    ``prefix`` introduces the first line as a markup item such as
+    ``- Parameter name:``; the lines that follow it are indented two spaces so
+    that they continue the same item. It is spec-derived too, so it goes
+    through the same line splitting rather than around it.
+    """
+    text = prefix + (doc.decode() if doc else fallback)
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    continuation = "  " if prefix else ""
+    # rstrip leaves a bare marker for an empty or whitespace-only line.
+    rendered = [f"{indent}/// {lines[0]}".rstrip()]
+    rendered += [f"{indent}/// {continuation}{line}".rstrip() for line in lines[1:]]
+    return "\n".join(rendered)
+
+
+def swift_string(text: str) -> str:
+    """Escape spec-derived text for a double-quoted Swift string literal.
+
+    A double quote ends the literal and a line terminator breaks it, letting
+    the rest of the text through as source; a backslash starts an escape or a
+    ``\\(`` interpolation, and consumes the character after it, the closing
+    quote included. The remaining control characters do not end
+    it but the compiler rejects them in source, so they go in as ``\\u{...}``.
+    Every escape used here preserves the original characters, so the on-chain
+    name the literal carries is unchanged.
+    """
+    escaped = (
+        text.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return "".join(
+        char if char >= " " and char != "\x7f" else f"\\u{{{ord(char):x}}}"
+        for char in escaped
+    )
+
+
 def prefixed_type_name(type_name: str, class_name: str, error_enum_names: frozenset = frozenset()) -> str:
     """Prefix a type name with the class name to avoid conflicts.
 
@@ -529,7 +576,7 @@ def render_enum(entry: xdr.SCSpecUDTEnumV0, class_name: str):
     """Generate Swift enum."""
     type_name = prefixed_type_name(entry.name.decode(), class_name)
     template = """
-/// {{ entry.doc.decode() if entry.doc else 'Generated enum ' + type_name }}
+{{ swift_doc(entry.doc, 'Generated enum ' + type_name) }}
 public enum {{ type_name }}: UInt32, Codable, CaseIterable {
     {%- for case in entry.cases %}
     case {{ escape_keyword(case.name.decode()) }} = {{ case.value.uint32 }}
@@ -545,23 +592,30 @@ public enum {{ type_name }}: UInt32, Codable, CaseIterable {
     /// - Throws: {{ class_name }}Error.conversionFailed if the SCVal is not a u32 or the value doesn't match any case
     public static func fromSCVal(_ val: SCValXDR) throws -> {{ type_name }} {
         guard case .u32(let value) = val else {
-            throw {{ class_name }}Error.conversionFailed(message: "Invalid SCVal type for {{ type_name }}")
+            throw {{ class_name }}Error.conversionFailed(message: "Invalid SCVal type for {{ swift_string(type_name) }}")
         }
         guard let enumCase = {{ type_name }}(rawValue: value) else {
-            throw {{ class_name }}Error.conversionFailed(message: "Invalid value for {{ type_name }}: \\(value)")
+            throw {{ class_name }}Error.conversionFailed(message: "Invalid value for {{ swift_string(type_name) }}: \\(value)")
         }
         return enumCase
     }
 }
 """
-    return Template(template).render(entry=entry, type_name=type_name, escape_keyword=escape_keyword, class_name=class_name)
+    return Template(template).render(
+        entry=entry,
+        type_name=type_name,
+        escape_keyword=escape_keyword,
+        class_name=class_name,
+        swift_doc=swift_doc,
+        swift_string=swift_string,
+    )
 
 
 def render_error_enum(entry: xdr.SCSpecUDTErrorEnumV0, class_name: str):
     """Generate Swift error enum."""
     type_name = prefixed_type_name(entry.name.decode(), class_name)
     template = """
-/// {{ entry.doc.decode() if entry.doc else 'Generated error enum ' + type_name }}
+{{ swift_doc(entry.doc, 'Generated error enum ' + type_name) }}
 public enum {{ type_name }}Error: UInt32, Error, Codable, CaseIterable {
     {%- for case in entry.cases %}
     case {{ escape_keyword(case.name.decode()) }} = {{ case.value.uint32 }}
@@ -577,16 +631,23 @@ public enum {{ type_name }}Error: UInt32, Error, Codable, CaseIterable {
     /// - Throws: {{ class_name }}Error.conversionFailed if the SCVal is not a u32 or the value doesn't match any case
     public static func fromSCVal(_ val: SCValXDR) throws -> {{ type_name }}Error {
         guard case .u32(let value) = val else {
-            throw {{ class_name }}Error.conversionFailed(message: "Invalid SCVal type for {{ type_name }}Error")
+            throw {{ class_name }}Error.conversionFailed(message: "Invalid SCVal type for {{ swift_string(type_name) }}Error")
         }
         guard let errorCase = {{ type_name }}Error(rawValue: value) else {
-            throw {{ class_name }}Error.conversionFailed(message: "Invalid value for {{ type_name }}Error: \\(value)")
+            throw {{ class_name }}Error.conversionFailed(message: "Invalid value for {{ swift_string(type_name) }}Error: \\(value)")
         }
         return errorCase
     }
 }
 """
-    return Template(template).render(entry=entry, type_name=type_name, escape_keyword=escape_keyword, class_name=class_name)
+    return Template(template).render(
+        entry=entry,
+        type_name=type_name,
+        escape_keyword=escape_keyword,
+        class_name=class_name,
+        swift_doc=swift_doc,
+        swift_string=swift_string,
+    )
 
 
 def render_struct(entry: xdr.SCSpecUDTStructV0, class_name: str, error_enum_names: frozenset = frozenset(), codable: bool = True):
@@ -609,7 +670,7 @@ def render_struct(entry: xdr.SCSpecUDTStructV0, class_name: str, error_enum_name
     # contract spec already provides sorted ascending by field name, so the map
     # entries need no explicit sort (unlike map arguments).
     template = """
-/// {{ entry.doc.decode() if entry.doc else 'Generated struct ' + type_name }}
+{{ swift_doc(entry.doc, 'Generated struct ' + type_name) }}
 public struct {{ type_name }}{{ codable_conformance }} {
     {%- for field in entry.fields %}
     public let {{ escape_keyword(field.name.decode()) }}: {{ to_swift_type(field.type) }}
@@ -629,7 +690,7 @@ public struct {{ type_name }}{{ codable_conformance }} {
         var mapEntries: [SCMapEntryXDR] = []
         {%- for field in entry.fields %}
         mapEntries.append(SCMapEntryXDR(
-            key: .symbol("{{ field.name.decode() }}"),
+            key: .symbol("{{ swift_string(field.name.decode()) }}"),
             val: {{ to_scval(field.type, escape_keyword(field.name.decode())) }}
         ))
         {%- endfor %}
@@ -642,7 +703,7 @@ public struct {{ type_name }}{{ codable_conformance }} {
     /// - Throws: {{ class_name }}Error.conversionFailed if the SCVal is not a map or required fields are missing
     public static func fromSCVal(_ val: SCValXDR) throws -> {{ type_name }} {
         guard case .map(let mapEntries) = val else {
-            throw {{ class_name }}Error.conversionFailed(message: "Invalid SCVal type for {{ type_name }}")
+            throw {{ class_name }}Error.conversionFailed(message: "Invalid SCVal type for {{ swift_string(type_name) }}")
         }
         
         var map: [String: SCValXDR] = [:]
@@ -653,8 +714,8 @@ public struct {{ type_name }}{{ codable_conformance }} {
         }
         
         {%- for field in entry.fields %}
-        guard let field_{{ loop.index0 }}_val = map["{{ field.name.decode() }}"] else {
-            throw {{ class_name }}Error.conversionFailed(message: "Missing required field '{{ field.name.decode() }}' in {{ type_name }}")
+        guard let field_{{ loop.index0 }}_val = map["{{ swift_string(field.name.decode()) }}"] else {
+            throw {{ class_name }}Error.conversionFailed(message: "Missing required field '{{ swift_string(field.name.decode()) }}' in {{ swift_string(type_name) }}")
         }
         {%- endfor %}
         
@@ -675,6 +736,8 @@ public struct {{ type_name }}{{ codable_conformance }} {
         escape_keyword=escape_keyword,
         class_name=class_name,
         codable_conformance=codable_conformance,
+        swift_doc=swift_doc,
+        swift_string=swift_string,
     )
 
 
@@ -694,7 +757,7 @@ def render_tuple_struct(entry: xdr.SCSpecUDTStructV0, class_name: str, error_enu
         return from_scval(td, name, class_name, throw_on_missing=False, error_enum_names=error_enum_names)
     
     template = """
-/// {{ entry.doc.decode() if entry.doc else 'Generated tuple struct ' + type_name }}
+{{ swift_doc(entry.doc, 'Generated tuple struct ' + type_name) }}
 public struct {{ type_name }}{{ codable_conformance }} {
     public let value: ({% for f in entry.fields %}{{ to_swift_type(f.type) }}{% if not loop.last %}, {% endif %}{% endfor %})
 
@@ -737,7 +800,7 @@ public struct {{ type_name }}{{ codable_conformance }} {
     /// - Throws: {{ class_name }}Error.conversionFailed if the SCVal is not a vec or has wrong number of elements
     public static func fromSCVal(_ val: SCValXDR) throws -> {{ type_name }} {
         guard case .vec(let elements) = val, let elements = elements else {
-            throw {{ class_name }}Error.conversionFailed(message: "Invalid SCVal type for {{ type_name }}")
+            throw {{ class_name }}Error.conversionFailed(message: "Invalid SCVal type for {{ swift_string(type_name) }}")
         }
         
         return {{ type_name }}(value: (
@@ -757,6 +820,8 @@ public struct {{ type_name }}{{ codable_conformance }} {
         class_name=class_name,
         codable=codable,
         codable_conformance=codable_conformance,
+        swift_doc=swift_doc,
+        swift_string=swift_string,
     )
 
 
@@ -777,7 +842,7 @@ def render_union(entry: xdr.SCSpecUDTUnionV0, class_name: str, error_enum_names:
         return from_scval(td, name, class_name, throw_on_missing=True, error_enum_names=error_enum_names)
     
     template = """
-/// {{ entry.doc.decode() if entry.doc else 'Generated union ' + type_name }}
+{{ swift_doc(entry.doc, 'Generated union ' + type_name) }}
 public enum {{ type_name }}{{ codable_conformance }} {
     {%- for case in entry.cases %}
     {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 %}
@@ -796,18 +861,18 @@ public enum {{ type_name }}{{ codable_conformance }} {
         {%- for case in entry.cases %}
         {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 %}
         case .{{ escape_keyword(case.void_case.name.decode()) }}:
-            return .vec([.symbol("{{ case.void_case.name.decode() }}")])
+            return .vec([.symbol("{{ swift_string(case.void_case.name.decode()) }}")])
         {%- else %}
         {%- if len(case.tuple_case.type) == 1 %}
         case .{{ escape_keyword(case.tuple_case.name.decode()) }}(let value):
             return .vec([
-                .symbol("{{ case.tuple_case.name.decode() }}"),
+                .symbol("{{ swift_string(case.tuple_case.name.decode()) }}"),
                 {{ to_scval(case.tuple_case.type[0], 'value') }}
             ])
         {%- else %}
         case .{{ escape_keyword(case.tuple_case.name.decode()) }}({% for i in range(len(case.tuple_case.type)) %}let value{{ i }}{% if not loop.last %}, {% endif %}{% endfor %}):
             return .vec([
-                .symbol("{{ case.tuple_case.name.decode() }}"),
+                .symbol("{{ swift_string(case.tuple_case.name.decode()) }}"),
                 {%- for i, t in enumerate(case.tuple_case.type) %}
                 {{ to_scval(t, 'value' ~ i|string) }}{% if not loop.last %},{% endif %}
                 {%- endfor %}
@@ -838,18 +903,18 @@ public enum {{ type_name }}{{ codable_conformance }} {
         switch kind {
         {%- for case in entry.cases %}
         {%- if case.kind == xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0 %}
-        case "{{ case.void_case.name.decode() }}":
+        case "{{ swift_string(case.void_case.name.decode()) }}":
             return .{{ escape_keyword(case.void_case.name.decode()) }}
         {%- else %}
-        case "{{ case.tuple_case.name.decode() }}":
+        case "{{ swift_string(case.tuple_case.name.decode()) }}":
             {%- if len(case.tuple_case.type) == 1 %}
             guard vec.count == 2 else {
-                throw {{ class_name }}Error.conversionFailed(message: "Invalid union value for {{ case.tuple_case.name.decode() }}: expected 2 elements")
+                throw {{ class_name }}Error.conversionFailed(message: "Invalid union value for {{ swift_string(case.tuple_case.name.decode()) }}: expected 2 elements")
             }
             return .{{ escape_keyword(case.tuple_case.name.decode()) }}({{ from_scval(case.tuple_case.type[0], 'vec[1]') }})
             {%- else %}
             guard vec.count == {{ len(case.tuple_case.type) + 1 }} else {
-                throw {{ class_name }}Error.conversionFailed(message: "Invalid union value for {{ case.tuple_case.name.decode() }}: expected {{ len(case.tuple_case.type) + 1 }} elements")
+                throw {{ class_name }}Error.conversionFailed(message: "Invalid union value for {{ swift_string(case.tuple_case.name.decode()) }}: expected {{ len(case.tuple_case.type) + 1 }} elements")
             }
             return .{{ escape_keyword(case.tuple_case.name.decode()) }}(
                 {%- for i, t in enumerate(case.tuple_case.type) %}
@@ -877,6 +942,8 @@ public enum {{ type_name }}{{ codable_conformance }} {
         enumerate=enumerate,
         escape_keyword=escape_keyword,
         codable_conformance=codable_conformance,
+        swift_doc=swift_doc,
+        swift_string=swift_string,
     )
 
 
@@ -921,9 +988,9 @@ public class {{ class_name }} {
     }
     {%- for entry in entries %}
     
-    /// {{ entry.doc.decode() if entry.doc else 'Invoke the ' + entry.name.sc_symbol.decode() + ' method' }}
+{{ swift_doc(entry.doc, 'Invoke the ' + entry.name.sc_symbol.decode() + ' method', '    ') }}
     /// {%- for param in entry.inputs %}
-    /// - Parameter {{ escape_keyword(param.name.decode()) }}: {{ param.doc.decode() if param.doc else to_swift_type(param.type) }}
+{{ swift_doc(param.doc, to_swift_type(param.type), '    ', '- Parameter ' + escape_keyword(param.name.decode()) + ': ') }}
     {%- endfor %}
     /// - Parameter methodOptions: Options for transaction (optional)
     /// - Parameter force: Force signing and sending even if it's a read call (default: false)
@@ -942,7 +1009,7 @@ public class {{ class_name }} {
         ]
         
         {{ "let result = " if parse_result_type(entry.outputs) != "Void" else "_ = " }}try await client.invokeMethod(
-            name: "{{ entry.name.sc_symbol.decode() }}",
+            name: "{{ swift_string(entry.name.sc_symbol.decode()) }}",
             args: args,
             force: force,
             methodOptions: methodOptions
@@ -952,10 +1019,10 @@ public class {{ class_name }} {
         {%- endif %}
     }
     
-    /// Build an AssembledTransaction for the {{ entry.name.sc_symbol.decode() }} method.
+{{ swift_doc(None, 'Build an AssembledTransaction for the ' + entry.name.sc_symbol.decode() + ' method.', '    ') }}
     /// This is useful if you need to manipulate the transaction before signing and sending.
     /// {%- for param in entry.inputs %}
-    /// - Parameter {{ escape_keyword(param.name.decode()) }}: {{ param.doc.decode() if param.doc else to_swift_type(param.type) }}
+{{ swift_doc(param.doc, to_swift_type(param.type), '    ', '- Parameter ' + escape_keyword(param.name.decode()) + ': ') }}
     {%- endfor %}
     /// - Parameter methodOptions: Options for transaction (optional)
     /// - Returns: AssembledTransaction
@@ -972,7 +1039,7 @@ public class {{ class_name }} {
         ]
         
         return try await client.buildInvokeMethodTx(
-            name: "{{ entry.name.sc_symbol.decode() }}",
+            name: "{{ swift_string(entry.name.sc_symbol.decode()) }}",
             args: args,
             methodOptions: methodOptions
         )
@@ -1046,7 +1113,9 @@ enum {{ class_name }}Error: Error {
         escape_keyword=escape_keyword,
         snake_to_camel=snake_to_camel,
         snake_to_pascal=snake_to_pascal,
-        len=len
+        len=len,
+        swift_doc=swift_doc,
+        swift_string=swift_string,
     )
 
 

--- a/tests/test_flutter_generator.py
+++ b/tests/test_flutter_generator.py
@@ -21,6 +21,8 @@ from stellar_contract_bindings.flutter import (
     render_tuple_struct,
     render_union,
     command,
+    dart_doc,
+    dart_string,
 )
 
 
@@ -700,7 +702,7 @@ class TestRenderUDTs:
         result = render_struct(struct_entry, "TestContract")
         assert "final BigInt createdAt;" in result
         assert "XdrSCVal.forTimepoint(createdAt)" in result
-        assert "createdAt: fieldsMap[\"created_at\"]!.timepoint!.uint64" in result
+        assert "createdAt: fieldsMap['created_at']!.timepoint!.uint64" in result
 
     def test_render_tuple_struct(self):
         tuple_struct_entry = xdr.SCSpecUDTStructV0(
@@ -1110,7 +1112,7 @@ class TestGenerateBinding:
         assert "final int for_;" in generated
         # The encoded symbol and decode lookup keep the original spec field name.
         assert "XdrSCVal.forSymbol('for')" in generated
-        assert 'for_: fieldsMap["for"]!.u32!.uint32,' in generated
+        assert "for_: fieldsMap['for']!.u32!.uint32," in generated
 
     def test_generate_binding_escapes_keyword_enum_and_error_enum_names(self):
         enum_spec = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
@@ -1334,3 +1336,331 @@ class TestFlutterMapKeySort:
         assert "_compareBytesLex" not in generated
         assert "_addressSortBytes" not in generated
         assert "import 'dart:convert';" not in generated
+
+
+# Spec text that would spill out of a single-marker comment, and a field name
+# that would end the literal it is rendered into.
+_SPILL_DOC = b"First line of the doc.\nSPILL_MARKER continues the doc."
+_HOSTILE_NAME = b"it's"
+
+
+def _esc_specs():
+    """One entry of every kind that carries a doc, each documented."""
+    enum_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    enum_entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocEnum",
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"First", value=xdr.Uint32(0))],
+    )
+
+    error_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0)
+    error_entry.udt_error_enum_v0 = xdr.SCSpecUDTErrorEnumV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocError",
+        cases=[xdr.SCSpecUDTErrorEnumCaseV0(doc=b"", name=b"Bad", value=xdr.Uint32(1))],
+    )
+
+    struct_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    struct_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocStruct",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=b"amount", type=_type(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+
+    tuple_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    tuple_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocTuple",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=b"0", type=_type(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+
+    union_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    union_entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocUnion",
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=b"Empty"),
+            )
+        ],
+    )
+
+    function_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_FUNCTION_V0)
+    function_entry.function_v0 = xdr.SCSpecFunctionV0(
+        doc=_SPILL_DOC,
+        name=xdr.SCSymbol(sc_symbol=b"documented"),
+        inputs=[
+            xdr.SCSpecFunctionInputV0(
+                doc=_SPILL_DOC, name=b"value", type=_type(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+        outputs=[],
+    )
+
+    return [
+        enum_entry,
+        error_entry,
+        struct_entry,
+        tuple_entry,
+        union_entry,
+        function_entry,
+    ]
+
+
+def _esc_doc_enum(doc: bytes):
+    """An enum carrying the given doc, for rendering that doc on its own."""
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=doc,
+        lib=b"",
+        name=b"DocEnum",
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"One", value=xdr.Uint32(0))],
+    )
+    return entry
+
+
+def _esc_field_struct(field_name: bytes):
+    """A one-field struct whose field name carries the given text."""
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=b"",
+        lib=b"",
+        name=b"Literal",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=field_name, type=_type(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+    return entry
+
+
+def _esc_union(case_name: bytes):
+    """A union with a void and a tuple case, both named from the given text."""
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=b"",
+        lib=b"",
+        name=b"Wire",
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=case_name),
+            ),
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_TUPLE_V0,
+                tuple_case=xdr.SCSpecUDTUnionCaseTupleV0(
+                    doc=b"",
+                    name=b"T" + case_name,
+                    type=[_type(xdr.SCSpecType.SC_SPEC_TYPE_U32)],
+                ),
+            ),
+        ],
+    )
+    return entry
+
+
+def _esc_function(symbol: bytes, returns_value: bool = False):
+    """A single function entry, for the client method sites.
+
+    The client templates emit a different invoke body for a void function than
+    for one that returns a value, so both shapes are needed to reach every
+    site that names the function.
+    """
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_FUNCTION_V0)
+    entry.function_v0 = xdr.SCSpecFunctionV0(
+        doc=b"",
+        name=xdr.SCSymbol(sc_symbol=symbol),
+        inputs=[
+            xdr.SCSpecFunctionInputV0(
+                doc=b"",
+                name=b"value",
+                type=_type(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+            )
+        ],
+        outputs=[_type(xdr.SCSpecType.SC_SPEC_TYPE_U32)] if returns_value else [],
+    )
+    return entry
+
+
+def _esc_udt_set(type_name: bytes):
+    """One UDT of every kind whose spec name carries the given text.
+
+    A UDT name reaches the diagnostic messages the generated code raises, so it
+    needs the same escaping as a field or case name.
+    """
+    enum_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    enum_entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=b"",
+        lib=b"",
+        name=type_name,
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"One", value=xdr.Uint32(0))],
+    )
+    error_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0)
+    error_entry.udt_error_enum_v0 = xdr.SCSpecUDTErrorEnumV0(
+        doc=b"",
+        lib=b"",
+        name=b"E" + type_name,
+        cases=[xdr.SCSpecUDTErrorEnumCaseV0(doc=b"", name=b"Bad", value=xdr.Uint32(1))],
+    )
+    struct_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    struct_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=b"",
+        lib=b"",
+        name=b"S" + type_name,
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(doc=b"", name=b"amount", type=_type(xdr.SCSpecType.SC_SPEC_TYPE_U32))
+        ],
+    )
+    tuple_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    tuple_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=b"",
+        lib=b"",
+        name=b"T" + type_name,
+        fields=[xdr.SCSpecUDTStructFieldV0(doc=b"", name=b"0", type=_type(xdr.SCSpecType.SC_SPEC_TYPE_U32))],
+    )
+    union_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    union_entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=b"",
+        lib=b"",
+        name=b"U" + type_name,
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=b"Empty"),
+            )
+        ],
+    )
+    return [enum_entry, error_entry, struct_entry, tuple_entry, union_entry]
+
+
+class TestSpecTextEscaping:
+    """Spec text reaches the output as comments and literals, never as source."""
+
+    # --- doc comments ---
+
+    def test_every_doc_site_marks_all_of_its_lines(self):
+        result = generate_binding(_esc_specs(), "DocContract")
+        marked = [line for line in result.splitlines() if "SPILL_MARKER" in line]
+        # One per documented declaration: enum, error enum, struct, tuple
+        # struct, union, and the client method. Dart doc comments carry no
+        # parameter descriptions.
+        assert len(marked) == 6
+        assert all(line.strip().startswith("///") for line in marked)
+
+    def test_doc_line_endings_are_normalized(self):
+        result = generate_binding(
+            [_esc_doc_enum(b"First.\r\nSecond.\rThird.")], "DocContract"
+        )
+        assert "\r" not in result
+        assert "/// First." in result
+        assert "/// Second." in result
+        assert "/// Third." in result
+
+    def test_carriage_return_only_doc_is_split(self):
+        result = generate_binding([_esc_doc_enum(b"One.\rTwo.")], "DocContract")
+        assert "\r" not in result
+        assert "/// One." in result
+        assert "/// Two." in result
+
+    def test_builder_doc_line_renders_the_function_name(self):
+        result = generate_binding([_esc_function(b"go_now")], "DocContract")
+        assert "/// Builds an AssembledTransaction for the go_now method." in result
+
+    def test_empty_doc_uses_the_fallback(self):
+        result = generate_binding([_esc_doc_enum(b"")], "DocContract")
+        assert "/// DocContractDocEnum enum" in result
+
+    def test_doc_of_only_newlines_emits_bare_markers(self):
+        assert dart_doc(b"\n\n", "unused") == "///\n///\n///"
+
+    def test_trailing_newline_emits_a_final_bare_marker(self):
+        assert dart_doc(b"text\n", "unused") == "/// text\n///"
+
+    def test_blank_doc_line_keeps_the_marker_without_trailing_space(self):
+        assert dart_doc(b"one\n\ntwo", "unused") == "/// one\n///\n/// two"
+
+    def test_whitespace_only_doc_line_carries_no_trailing_space(self):
+        assert dart_doc(b"one\n   \ntwo", "unused") == "/// one\n///\n/// two"
+
+    def test_indent_applies_to_every_line(self):
+        assert dart_doc(b"one\ntwo", "unused", "  ") == "  /// one\n  /// two"
+
+    def test_udt_name_is_escaped_in_diagnostic_messages(self):
+        result = generate_binding(_esc_udt_set(b"Va$lue"), "C")
+        assert "ArgumentError('Unknown CVa\\$lue value: $value')" in result
+        assert "ArgumentError('Unknown CEVa\\$lue value: $value')" in result
+        assert "ArgumentError('Unknown CUVa\\$lueKind value: $value')" in result
+        assert "'Unknown CVa$lue value:" not in result
+
+    # --- string literals ---
+
+    def test_field_name_is_escaped_on_both_encode_and_decode(self):
+        # The encode site writes the map key and the decode site reads it back;
+        # escaping only one of them yields a client that cannot round-trip.
+        result = generate_binding([_esc_field_struct(_HOSTILE_NAME)], "DocContract")
+        assert "XdrSCVal.forSymbol('it\\'s')" in result
+        assert "fieldsMap['it\\'s']" in result
+        assert "fieldsMap['it's']" not in result
+
+    def test_field_name_cannot_start_an_interpolation(self):
+        result = generate_binding([_esc_field_struct(b"cost$total")], "DocContract")
+        assert "XdrSCVal.forSymbol('cost\\$total')" in result
+        assert "fieldsMap['cost\\$total']" in result
+        assert "fieldsMap['cost$total']" not in result
+
+    def test_union_case_names_are_escaped_in_the_kind_enum(self):
+        result = generate_binding([_esc_union(b"Va'r")], "DocContract")
+        assert "('Va\\'r')" in result
+        assert "('TVa\\'r')" in result
+        assert "('Va'r')" not in result
+
+    def test_client_method_name_is_escaped_at_both_call_sites(self):
+        # The invoke method and the transaction builder each name the function.
+        result = generate_binding([_esc_function(b"go's")], "DocContract")
+        assert result.count("name: 'go\\'s',") == 2
+        assert "name: 'go's'," not in result
+
+    def test_client_method_name_is_escaped_when_the_call_returns_a_value(self):
+        # A returning function renders a different invoke body than a void one.
+        result = generate_binding(
+            [_esc_function(b"go's", returns_value=True)], "DocContract"
+        )
+        assert result.count("name: 'go\\'s',") == 2
+        assert "name: 'go's'," not in result
+
+    # --- the escaper itself ---
+
+    def test_dart_string_escapes_preserve_the_original_text(self):
+        assert dart_string("back\\slash") == "back\\\\slash"
+        assert dart_string("it's") == "it\\'s"
+        assert dart_string("cost$total") == "cost\\$total"
+        assert dart_string("line\nbreak") == "line\\nbreak"
+        assert dart_string("line\rbreak") == "line\\rbreak"
+        assert dart_string("tab\there") == "tab\\there"
+
+    def test_dart_string_escapes_the_backslash_first(self):
+        # Escaping the quote first would leave the backslash it introduced
+        # unescaped, and the literal would end early.
+        assert dart_string("a\\'b") == "a\\\\\\'b"
+
+    def test_dart_string_replaces_control_characters(self):
+        assert dart_string("a\x0bb") == "a\\u{b}b"
+        assert dart_string("a\x7fb") == "a\\u{7f}b"
+
+    def test_dart_string_leaves_ordinary_text_alone(self):
+        assert dart_string("transfer_from") == "transfer_from"

--- a/tests/test_kotlin_generator.py
+++ b/tests/test_kotlin_generator.py
@@ -29,6 +29,8 @@ from stellar_contract_bindings.kmp import (
     render_client,
     generate_binding,
     command,
+    kotlin_doc,
+    kotlin_string,
 )
 
 
@@ -1149,3 +1151,360 @@ class TestCommand:
                 "class Contract internal constructor(val client: ContractClient)"
                 in content
             )
+
+
+# Spec text that would lose its marker or close the block comment it is
+# rendered into, and a field name that would end its string literal.
+_SPILL_DOC = b"First line of the doc.\nSPILL_MARKER continues the doc."
+_HOSTILE_NAME = b'co$t"x'
+
+
+def _esc_specs():
+    """One entry of every kind that carries a doc, each documented."""
+    enum_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    enum_entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocEnum",
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"First", value=xdr.Uint32(0))],
+    )
+
+    error_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0)
+    error_entry.udt_error_enum_v0 = xdr.SCSpecUDTErrorEnumV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocError",
+        cases=[xdr.SCSpecUDTErrorEnumCaseV0(doc=b"", name=b"Bad", value=xdr.Uint32(1))],
+    )
+
+    struct_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    struct_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocStruct",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=b"amount", type=_t(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+
+    tuple_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    tuple_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocTuple",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=b"0", type=_t(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+
+    union_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    union_entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocUnion",
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=b"Empty"),
+            )
+        ],
+    )
+
+    function_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_FUNCTION_V0)
+    function_entry.function_v0 = xdr.SCSpecFunctionV0(
+        doc=_SPILL_DOC,
+        name=xdr.SCSymbol(sc_symbol=b"documented"),
+        inputs=[
+            xdr.SCSpecFunctionInputV0(
+                doc=_SPILL_DOC, name=b"value", type=_t(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+        outputs=[],
+    )
+
+    return [
+        enum_entry,
+        error_entry,
+        struct_entry,
+        tuple_entry,
+        union_entry,
+        function_entry,
+    ]
+
+
+def _esc_doc_enum(doc: bytes):
+    """An enum carrying the given doc, for rendering that doc on its own."""
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=doc,
+        lib=b"",
+        name=b"DocEnum",
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"One", value=xdr.Uint32(0))],
+    )
+    return entry
+
+
+def _esc_field_struct(field_name: bytes):
+    """A one-field struct whose field name carries the given text."""
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=b"",
+        lib=b"",
+        name=b"Literal",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=field_name, type=_t(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+    return entry
+
+
+def _esc_union(case_name: bytes):
+    """A union with a void and a tuple case, both named from the given text."""
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=b"",
+        lib=b"",
+        name=b"Wire",
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=case_name),
+            ),
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_TUPLE_V0,
+                tuple_case=xdr.SCSpecUDTUnionCaseTupleV0(
+                    doc=b"",
+                    name=b"T" + case_name,
+                    type=[_t(xdr.SCSpecType.SC_SPEC_TYPE_U32)],
+                ),
+            ),
+        ],
+    )
+    return entry
+
+
+def _esc_function(symbol: bytes, returns_value: bool = False):
+    """A single function entry, for the client method sites.
+
+    The client templates emit a different invoke body for a void function than
+    for one that returns a value, so both shapes are needed to reach every
+    site that names the function.
+    """
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_FUNCTION_V0)
+    entry.function_v0 = xdr.SCSpecFunctionV0(
+        doc=b"",
+        name=xdr.SCSymbol(sc_symbol=symbol),
+        inputs=[
+            xdr.SCSpecFunctionInputV0(
+                doc=b"",
+                name=b"value",
+                type=_t(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+            )
+        ],
+        outputs=[_t(xdr.SCSpecType.SC_SPEC_TYPE_U32)] if returns_value else [],
+    )
+    return entry
+
+
+def _esc_udt_set(type_name: bytes):
+    """One UDT of every kind whose spec name carries the given text.
+
+    A UDT name reaches the diagnostic messages the generated code raises, so it
+    needs the same escaping as a field or case name.
+    """
+    enum_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    enum_entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=b"",
+        lib=b"",
+        name=type_name,
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"One", value=xdr.Uint32(0))],
+    )
+    error_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0)
+    error_entry.udt_error_enum_v0 = xdr.SCSpecUDTErrorEnumV0(
+        doc=b"",
+        lib=b"",
+        name=b"E" + type_name,
+        cases=[xdr.SCSpecUDTErrorEnumCaseV0(doc=b"", name=b"Bad", value=xdr.Uint32(1))],
+    )
+    struct_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    struct_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=b"",
+        lib=b"",
+        name=b"S" + type_name,
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(doc=b"", name=b"amount", type=_t(xdr.SCSpecType.SC_SPEC_TYPE_U32))
+        ],
+    )
+    tuple_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    tuple_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=b"",
+        lib=b"",
+        name=b"T" + type_name,
+        fields=[xdr.SCSpecUDTStructFieldV0(doc=b"", name=b"0", type=_t(xdr.SCSpecType.SC_SPEC_TYPE_U32))],
+    )
+    union_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    union_entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=b"",
+        lib=b"",
+        name=b"U" + type_name,
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=b"Empty"),
+            )
+        ],
+    )
+    return [enum_entry, error_entry, struct_entry, tuple_entry, union_entry]
+
+
+class TestSpecTextEscaping:
+    """Spec text reaches the output as comments and literals, never as source."""
+
+    # --- doc comments ---
+
+    def test_every_doc_site_marks_all_of_its_lines(self):
+        result = generate_binding(
+            _esc_specs(), package="com.example", class_name="DocContract"
+        )
+        marked = [line for line in result.splitlines() if "SPILL_MARKER" in line]
+        # Five documented declarations, the client method, and the @param
+        # description on both the invoke method and the transaction builder.
+        assert len(marked) == 8
+        assert all(line.strip().startswith("*") for line in marked)
+
+    def test_parameter_description_continues_under_its_tag(self):
+        result = generate_binding(
+            _esc_specs(), package="com.example", class_name="DocContract"
+        )
+        assert "* @param value First line of the doc." in result
+        assert "*   SPILL_MARKER continues the doc." in result
+
+    def test_doc_cannot_close_the_block_comment(self):
+        result = generate_binding(
+            [_esc_doc_enum(b"ends */ here")],
+            package="com.example",
+            class_name="DocContract",
+        )
+        assert " * ends *\\/ here" in result
+        assert "ends */ here" not in result
+
+    def test_doc_cannot_open_a_nested_block_comment(self):
+        # Kotlin nests block comments, so an unescaped /* would swallow the
+        # code after the block's own terminator.
+        result = generate_binding(
+            [_esc_doc_enum(b"opens /* here")],
+            package="com.example",
+            class_name="DocContract",
+        )
+        assert " * opens /\\* here" in result
+        assert "opens /* here" not in result
+
+    def test_prefix_is_escaped_and_split_like_the_text(self):
+        # The tag carries a spec-derived parameter name, so it needs the same
+        # treatment as the description that follows it.
+        assert kotlin_doc(b"desc", "fb", "", "@param x*/ ") == " * @param x*\\/ desc"
+        assert kotlin_doc(b"desc", "fb", "", "@param a\nb ") == " * @param a\n *   b desc"
+
+    def test_builder_doc_line_renders_the_function_name(self):
+        result = generate_binding(
+            [_esc_function(b"go_now")], package="com.example", class_name="DocContract"
+        )
+        assert "* Build an [AssembledTransaction] for the go_now contract function." in result
+
+    def test_doc_line_endings_are_normalized(self):
+        result = generate_binding(
+            [_esc_doc_enum(b"First.\r\nSecond.\rThird.")],
+            package="com.example",
+            class_name="DocContract",
+        )
+        assert "\r" not in result
+        assert " * First." in result
+        assert " * Second." in result
+        assert " * Third." in result
+
+    def test_empty_doc_uses_the_fallback(self):
+        result = generate_binding(
+            [_esc_doc_enum(b"")], package="com.example", class_name="DocContract"
+        )
+        assert " * Generated enum DocContractDocEnum" in result
+
+    def test_doc_of_only_newlines_emits_bare_markers(self):
+        assert kotlin_doc(b"\n\n", "unused") == " *\n *\n *"
+
+    def test_trailing_newline_emits_a_final_bare_marker(self):
+        assert kotlin_doc(b"text\n", "unused") == " * text\n *"
+
+    def test_blank_doc_line_keeps_the_marker_without_trailing_space(self):
+        assert kotlin_doc(b"one\n\ntwo", "unused") == " * one\n *\n * two"
+
+    def test_udt_name_is_escaped_in_diagnostic_messages(self):
+        result = generate_binding(
+            _esc_udt_set(b"Va$lue"), package="com.example", class_name="C"
+        )
+        assert 'IllegalArgumentException("Unknown CVa\\$lue value: $value")' in result
+        assert 'IllegalArgumentException("Unknown CEVa\\$lue value: $value")' in result
+        assert 'IllegalArgumentException("Unknown CUVa\\$lue tag: $tag")' in result
+        assert '"Unknown CVa$lue value:' not in result
+
+    # --- string literals ---
+
+    def test_field_name_is_escaped_on_both_encode_and_decode(self):
+        # The encode site writes the map key and the decode site reads it back;
+        # escaping only one of them yields a client that cannot round-trip.
+        result = generate_binding(
+            [_esc_field_struct(_HOSTILE_NAME)],
+            package="com.example",
+            class_name="DocContract",
+        )
+        assert result.count('Scv.toSymbol("co\\$t\\"x")') == 2
+        assert 'Scv.toSymbol("co$t"x")' not in result
+
+    def test_union_case_names_are_escaped_in_every_literal(self):
+        result = generate_binding(
+            [_esc_union(b"Va$r")], package="com.example", class_name="DocContract"
+        )
+        assert 'Scv.toSymbol("Va\\$r")' in result
+        assert 'Scv.toSymbol("TVa\\$r")' in result
+        assert '"Va\\$r" ->' in result
+        assert '"TVa\\$r" ->' in result
+        assert 'Scv.toSymbol("Va$r")' not in result
+
+    def test_client_method_name_is_escaped_at_every_call_site(self):
+        # A void call and a returning call render different invoke bodies, and
+        # each pairs with the transaction builder.
+        for returns_value in (False, True):
+            result = generate_binding(
+                [_esc_function(b"go$x", returns_value=returns_value)],
+                package="com.example",
+                class_name="DocContract",
+            )
+            assert result.count('functionName = "go\\$x",') == 2
+            assert 'functionName = "go$x",' not in result
+
+    # --- the escaper itself ---
+
+    def test_kotlin_string_escapes_preserve_the_original_text(self):
+        assert kotlin_string("back\\slash") == "back\\\\slash"
+        assert kotlin_string('say"hi') == 'say\\"hi'
+        assert kotlin_string("cost$total") == "cost\\$total"
+        assert kotlin_string("line\nbreak") == "line\\nbreak"
+        assert kotlin_string("line\rbreak") == "line\\rbreak"
+        assert kotlin_string("tab\there") == "tab\\there"
+
+    def test_kotlin_string_escapes_the_backslash_first(self):
+        # Escaping the quote first would leave the backslash it introduced
+        # unescaped, and the literal would end early.
+        assert kotlin_string('a\\"b') == 'a\\\\\\"b'
+
+    def test_kotlin_string_replaces_control_characters(self):
+        assert kotlin_string("a\x0bb") == "a\\u000bb"
+        assert kotlin_string("a\x7fb") == "a\\u007fb"
+
+    def test_kotlin_string_leaves_ordinary_text_alone(self):
+        assert kotlin_string("transfer_from") == "transfer_from"

--- a/tests/test_php_generator.py
+++ b/tests/test_php_generator.py
@@ -24,6 +24,8 @@ from stellar_contract_bindings.php import (
     render_tuple_struct,
     render_union,
     generate_binding,
+    php_doc,
+    php_string,
 )
 
 
@@ -1338,6 +1340,304 @@ class TestPHPCommand(unittest.TestCase):
                 result = runner.invoke(command, ["--contract-id", self.CONTRACT_ID])
             self.assertEqual(result.exit_code, 0, result.output)
             self.assertTrue(os.path.exists("ContractClient.php"))
+
+
+# Spec text that would lose its marker or close the block comment it is
+# rendered into, and a field name that would end its string literal.
+_SPILL_DOC = b"First line of the doc.\nSPILL_MARKER continues the doc."
+_HOSTILE_NAME = b"it's"
+
+
+def _esc_specs():
+    """One entry of every kind that carries a doc, each documented."""
+    enum_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    enum_entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocEnum",
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"First", value=xdr.Uint32(0))],
+    )
+
+    error_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0)
+    error_entry.udt_error_enum_v0 = xdr.SCSpecUDTErrorEnumV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocError",
+        cases=[xdr.SCSpecUDTErrorEnumCaseV0(doc=b"", name=b"Bad", value=xdr.Uint32(1))],
+    )
+
+    struct_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    struct_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocStruct",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=b"amount", type=xdr.SCSpecTypeDef(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+
+    tuple_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    tuple_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocTuple",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=b"0", type=xdr.SCSpecTypeDef(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+
+    union_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    union_entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocUnion",
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=b"Empty"),
+            )
+        ],
+    )
+
+    function_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_FUNCTION_V0)
+    function_entry.function_v0 = xdr.SCSpecFunctionV0(
+        doc=_SPILL_DOC,
+        name=xdr.SCSymbol(sc_symbol=b"documented"),
+        inputs=[
+            xdr.SCSpecFunctionInputV0(
+                doc=_SPILL_DOC, name=b"value", type=xdr.SCSpecTypeDef(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+        outputs=[],
+    )
+
+    return [
+        enum_entry,
+        error_entry,
+        struct_entry,
+        tuple_entry,
+        union_entry,
+        function_entry,
+    ]
+
+
+def _esc_doc_enum(doc: bytes):
+    """An enum carrying the given doc, for rendering that doc on its own."""
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=doc,
+        lib=b"",
+        name=b"DocEnum",
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"One", value=xdr.Uint32(0))],
+    )
+    return entry
+
+
+def _esc_field_struct(field_name: bytes):
+    """A one-field struct whose field name carries the given text."""
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=b"",
+        lib=b"",
+        name=b"Literal",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=field_name, type=xdr.SCSpecTypeDef(xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+    return entry
+
+
+def _esc_union(case_name: bytes, payload_types: int = 1):
+    """A union with a void and a tuple case, both named from the given text.
+
+    A tuple case carrying more than one payload type renders through a
+    separate template branch, so the arity is a parameter.
+    """
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=b"",
+        lib=b"",
+        name=b"Wire",
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=case_name),
+            ),
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_TUPLE_V0,
+                tuple_case=xdr.SCSpecUDTUnionCaseTupleV0(
+                    doc=b"",
+                    name=b"T" + case_name,
+                    type=[xdr.SCSpecTypeDef(xdr.SCSpecType.SC_SPEC_TYPE_U32)] * payload_types,
+                ),
+            ),
+        ],
+    )
+    return entry
+
+
+def _esc_function(
+    symbol: bytes,
+    param_doc: bytes = b"",
+    param_name: bytes = b"value",
+    returns_value: bool = False,
+):
+    """A single function entry, for the client method sites.
+
+    The client templates emit a different invoke body for a void function than
+    for one that returns a value, so both shapes are needed to reach every
+    site that names the function.
+    """
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_FUNCTION_V0)
+    entry.function_v0 = xdr.SCSpecFunctionV0(
+        doc=b"",
+        name=xdr.SCSymbol(sc_symbol=symbol),
+        inputs=[
+            xdr.SCSpecFunctionInputV0(
+                doc=param_doc,
+                name=param_name,
+                type=xdr.SCSpecTypeDef(xdr.SCSpecType.SC_SPEC_TYPE_U32),
+            )
+        ],
+        outputs=[xdr.SCSpecTypeDef(xdr.SCSpecType.SC_SPEC_TYPE_U32)] if returns_value else [],
+    )
+    return entry
+
+
+class TestSpecTextEscaping(unittest.TestCase):
+    """Spec text reaches the output as comments and literals, never as source."""
+
+    # --- doc comments ---
+
+    def test_every_doc_site_marks_all_of_its_lines(self):
+        result = generate_binding(_esc_specs(), contract_name="DocContract")
+        marked = [line for line in result.splitlines() if "SPILL_MARKER" in line]
+        # Five documented declarations, the client method, and the @param
+        # description on both the invoke method and the transaction builder.
+        self.assertEqual(len(marked), 8)
+        self.assertTrue(all(line.strip().startswith("*") for line in marked))
+
+    def test_parameter_description_continues_under_its_tag(self):
+        result = generate_binding(_esc_specs(), contract_name="DocContract")
+        self.assertIn("* @param int $value First line of the doc.", result)
+        self.assertIn("*   SPILL_MARKER continues the doc.", result)
+
+    def test_doc_cannot_close_the_block_comment(self):
+        result = generate_binding(
+            [_esc_doc_enum(b"ends */ here")], contract_name="DocContract"
+        )
+        self.assertIn(" * ends *\\/ here", result)
+        self.assertNotIn("ends */ here", result)
+
+    def test_parameter_tag_cannot_close_the_block_comment(self):
+        # The tag carries a spec-derived parameter name, so it needs the same
+        # treatment as the description that follows it.
+        result = generate_binding(
+            [_esc_function(b"invoke", param_doc=b"desc", param_name=b"p*/x")],
+            contract_name="DocContract",
+        )
+        self.assertIn("* @param int $p*\\/x desc", result)
+        self.assertNotIn("@param int $p*/x", result)
+
+    def test_builder_doc_line_renders_the_function_name(self):
+        result = generate_binding(
+            [_esc_function(b"go_now")], contract_name="DocContract"
+        )
+        self.assertIn("* Build an AssembledTransaction for the go_now method.", result)
+
+    def test_doc_line_endings_are_normalized(self):
+        result = generate_binding(
+            [_esc_doc_enum(b"First.\r\nSecond.\rThird.")], contract_name="DocContract"
+        )
+        self.assertNotIn("\r", result)
+        self.assertIn(" * First.", result)
+        self.assertIn(" * Second.", result)
+        self.assertIn(" * Third.", result)
+
+    def test_empty_doc_uses_the_fallback(self):
+        result = generate_binding([_esc_doc_enum(b"")], contract_name="DocContract")
+        self.assertIn(" * Generated enum DocContractDocEnum", result)
+
+    def test_doc_of_only_newlines_emits_bare_markers(self):
+        self.assertEqual(php_doc(b"\n\n", "unused"), " *\n *\n *")
+
+    def test_trailing_newline_emits_a_final_bare_marker(self):
+        self.assertEqual(php_doc(b"text\n", "unused"), " * text\n *")
+
+    def test_blank_doc_line_keeps_the_marker_without_trailing_space(self):
+        self.assertEqual(php_doc(b"one\n\ntwo", "unused"), " * one\n *\n * two")
+
+    def test_prefix_is_split_and_escaped_like_the_text(self):
+        self.assertEqual(php_doc(b"desc", "fb", "", "@param x*/ "), " * @param x*\\/ desc")
+        self.assertEqual(php_doc(b"desc", "fb", "", "@param a\nb "), " * @param a\n *   b desc")
+
+    def test_error_enum_suffix_trails_the_spec_text(self):
+        self.assertEqual(php_doc(b"doc", "fb", suffix=" (Error enum)"), " * doc (Error enum)")
+        self.assertEqual(php_doc(None, "fb", suffix=" (Error enum)"), " * fb")
+
+    # --- string literals ---
+
+    def test_field_name_is_escaped_on_both_encode_and_decode(self):
+        # The encode site writes the map key and the decode site reads it back;
+        # escaping only one of them yields a client that cannot round-trip.
+        result = generate_binding(
+            [_esc_field_struct(_HOSTILE_NAME)], contract_name="DocContract"
+        )
+        self.assertIn("XdrSCVal::forSymbol('it\\'s')", result)
+        self.assertIn("$map['it\\'s']", result)
+        self.assertNotIn("$map['it's']", result)
+
+    def test_union_case_names_are_escaped_in_every_literal(self):
+        result = generate_binding([_esc_union(b"Va'r")], contract_name="DocContract")
+        self.assertIn("= 'Va\\'r'", result)
+        self.assertIn("= 'TVa\\'r'", result)
+        self.assertIn("case 'Va\\'r':", result)
+        self.assertIn("case 'TVa\\'r':", result)
+        self.assertIn("Invalid union value for TVa\\'r", result)
+        self.assertNotIn("'Va'r'", result)
+
+    def test_union_case_name_is_escaped_in_the_multi_payload_branch(self):
+        # A tuple case with more than one payload renders its own decode guard.
+        result = generate_binding(
+            [_esc_union(b"Va'r", payload_types=2)], contract_name="DocContract"
+        )
+        self.assertIn("Invalid union value for TVa\\'r: expected 3 elements", result)
+        self.assertNotIn("Invalid union value for TVa'r", result)
+
+    def test_client_method_name_is_escaped_at_both_call_sites(self):
+        for returns_value in (False, True):
+            result = generate_binding(
+                [_esc_function(b"go's", returns_value=returns_value)],
+                contract_name="DocContract",
+            )
+            self.assertEqual(result.count("name: 'go\\'s',"), 2)
+            self.assertNotIn("name: 'go's',", result)
+
+    # --- the escaper itself ---
+
+    def test_php_string_escapes_preserve_the_original_text(self):
+        self.assertEqual(php_string("back\\slash"), "back\\\\slash")
+        self.assertEqual(php_string("it's"), "it\\'s")
+
+    def test_php_string_escapes_the_backslash_first(self):
+        # Escaping the quote first would leave the backslash it introduced
+        # unescaped, and the literal would end early.
+        self.assertEqual(php_string("a\\'b"), "a\\\\\\'b")
+
+    def test_php_string_leaves_text_single_quotes_cannot_escape(self):
+        # Single quotes recognize no other escape, so a backslash added here
+        # would survive into the value.
+        self.assertEqual(php_string("line\nbreak"), "line\nbreak")
+        self.assertEqual(php_string("cost$total"), "cost$total")
+
+    def test_php_string_leaves_ordinary_text_alone(self):
+        self.assertEqual(php_string("transfer_from"), "transfer_from")
 
 
 if __name__ == "__main__":

--- a/tests/test_swift_generator.py
+++ b/tests/test_swift_generator.py
@@ -29,6 +29,8 @@ from stellar_contract_bindings.swift import (
     generate_binding,
     compute_codable_capability,
     command,
+    swift_doc,
+    swift_string,
 )
 
 
@@ -1701,6 +1703,350 @@ class TestSwiftCommand:
             assert os.path.exists(path)
             with open(path) as f:
                 assert "public class ContractClient {" in f.read()
+
+
+# Spec text that would spill out of a single-marker comment, and a field name
+# that would end the literal it is rendered into.
+_SPILL_DOC = b"First line of the doc.\nSPILL_MARKER continues the doc."
+_HOSTILE_NAME = b'say"hi'
+
+
+def _esc_specs():
+    """One entry of every kind that carries a doc, each documented."""
+    enum_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    enum_entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocEnum",
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"First", value=xdr.Uint32(0))],
+    )
+
+    error_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0)
+    error_entry.udt_error_enum_v0 = xdr.SCSpecUDTErrorEnumV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocError",
+        cases=[xdr.SCSpecUDTErrorEnumCaseV0(doc=b"", name=b"Bad", value=xdr.Uint32(1))],
+    )
+
+    struct_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    struct_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocStruct",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=b"amount", type=xdr.SCSpecTypeDef(type=xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+
+    tuple_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    tuple_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocTuple",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=b"0", type=xdr.SCSpecTypeDef(type=xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+
+    union_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    union_entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=_SPILL_DOC,
+        lib=b"",
+        name=b"DocUnion",
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=b"Empty"),
+            )
+        ],
+    )
+
+    function_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_FUNCTION_V0)
+    function_entry.function_v0 = xdr.SCSpecFunctionV0(
+        doc=_SPILL_DOC,
+        name=xdr.SCSymbol(sc_symbol=b"documented"),
+        inputs=[
+            xdr.SCSpecFunctionInputV0(
+                doc=_SPILL_DOC, name=b"value", type=xdr.SCSpecTypeDef(type=xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+        outputs=[],
+    )
+
+    return [
+        enum_entry,
+        error_entry,
+        struct_entry,
+        tuple_entry,
+        union_entry,
+        function_entry,
+    ]
+
+
+def _esc_doc_enum(doc: bytes):
+    """An enum carrying the given doc, for rendering that doc on its own."""
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=doc,
+        lib=b"",
+        name=b"DocEnum",
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"One", value=xdr.Uint32(0))],
+    )
+    return entry
+
+
+def _esc_field_struct(field_name: bytes):
+    """A one-field struct whose field name carries the given text."""
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=b"",
+        lib=b"",
+        name=b"Literal",
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(
+                doc=b"", name=field_name, type=xdr.SCSpecTypeDef(type=xdr.SCSpecType.SC_SPEC_TYPE_U32)
+            )
+        ],
+    )
+    return entry
+
+
+def _esc_union(case_name: bytes, payload_types: int = 1):
+    """A union with a void and a tuple case, both named from the given text.
+
+    A tuple case carrying more than one payload type renders through a
+    separate template branch, so the arity is a parameter.
+    """
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=b"",
+        lib=b"",
+        name=b"Wire",
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=case_name),
+            ),
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_TUPLE_V0,
+                tuple_case=xdr.SCSpecUDTUnionCaseTupleV0(
+                    doc=b"",
+                    name=b"T" + case_name,
+                    type=[xdr.SCSpecTypeDef(type=xdr.SCSpecType.SC_SPEC_TYPE_U32)] * payload_types,
+                ),
+            ),
+        ],
+    )
+    return entry
+
+
+def _esc_function(symbol: bytes, returns_value: bool = False):
+    """A single function entry, for the client method sites.
+
+    The client templates emit a different invoke body for a void function than
+    for one that returns a value, so both shapes are needed to reach every
+    site that names the function.
+    """
+    entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_FUNCTION_V0)
+    entry.function_v0 = xdr.SCSpecFunctionV0(
+        doc=b"",
+        name=xdr.SCSymbol(sc_symbol=symbol),
+        inputs=[
+            xdr.SCSpecFunctionInputV0(
+                doc=b"",
+                name=b"value",
+                type=xdr.SCSpecTypeDef(type=xdr.SCSpecType.SC_SPEC_TYPE_U32),
+            )
+        ],
+        outputs=[xdr.SCSpecTypeDef(type=xdr.SCSpecType.SC_SPEC_TYPE_U32)] if returns_value else [],
+    )
+    return entry
+
+
+def _esc_udt_set(type_name: bytes):
+    """One UDT of every kind whose spec name carries the given text.
+
+    A UDT name reaches the diagnostic messages the generated code raises, so it
+    needs the same escaping as a field or case name.
+    """
+    enum_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ENUM_V0)
+    enum_entry.udt_enum_v0 = xdr.SCSpecUDTEnumV0(
+        doc=b"",
+        lib=b"",
+        name=type_name,
+        cases=[xdr.SCSpecUDTEnumCaseV0(doc=b"", name=b"One", value=xdr.Uint32(0))],
+    )
+    error_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_ERROR_ENUM_V0)
+    error_entry.udt_error_enum_v0 = xdr.SCSpecUDTErrorEnumV0(
+        doc=b"",
+        lib=b"",
+        name=b"E" + type_name,
+        cases=[xdr.SCSpecUDTErrorEnumCaseV0(doc=b"", name=b"Bad", value=xdr.Uint32(1))],
+    )
+    struct_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    struct_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=b"",
+        lib=b"",
+        name=b"S" + type_name,
+        fields=[
+            xdr.SCSpecUDTStructFieldV0(doc=b"", name=b"amount", type=xdr.SCSpecTypeDef(type=xdr.SCSpecType.SC_SPEC_TYPE_U32))
+        ],
+    )
+    tuple_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_STRUCT_V0)
+    tuple_entry.udt_struct_v0 = xdr.SCSpecUDTStructV0(
+        doc=b"",
+        lib=b"",
+        name=b"T" + type_name,
+        fields=[xdr.SCSpecUDTStructFieldV0(doc=b"", name=b"0", type=xdr.SCSpecTypeDef(type=xdr.SCSpecType.SC_SPEC_TYPE_U32))],
+    )
+    union_entry = xdr.SCSpecEntry(xdr.SCSpecEntryKind.SC_SPEC_ENTRY_UDT_UNION_V0)
+    union_entry.udt_union_v0 = xdr.SCSpecUDTUnionV0(
+        doc=b"",
+        lib=b"",
+        name=b"U" + type_name,
+        cases=[
+            xdr.SCSpecUDTUnionCaseV0(
+                xdr.SCSpecUDTUnionCaseV0Kind.SC_SPEC_UDT_UNION_CASE_VOID_V0,
+                void_case=xdr.SCSpecUDTUnionCaseVoidV0(doc=b"", name=b"Empty"),
+            )
+        ],
+    )
+    return [enum_entry, error_entry, struct_entry, tuple_entry, union_entry]
+
+
+class TestSpecTextEscaping:
+    """Spec text reaches the output as comments and literals, never as source."""
+
+    # --- doc comments ---
+
+    def test_every_doc_site_marks_all_of_its_lines(self):
+        result = generate_binding(_esc_specs(), "DocContract")
+        marked = [line for line in result.splitlines() if "SPILL_MARKER" in line]
+        # Five documented declarations, the client method, and the parameter
+        # description on both the invoke method and the transaction builder.
+        assert len(marked) == 8
+        assert all(line.strip().startswith("///") for line in marked)
+
+    def test_parameter_description_continues_under_its_tag(self):
+        result = generate_binding(_esc_specs(), "DocContract")
+        assert "/// - Parameter value: First line of the doc." in result
+        assert "///   SPILL_MARKER continues the doc." in result
+
+    def test_prefix_is_split_like_the_text(self):
+        # The tag carries a spec-derived parameter name, so a newline in it
+        # would leave the comment just as one in the description would.
+        assert (
+            swift_doc(b"desc", "fb", "", "- Parameter a\nb: ")
+            == "/// - Parameter a\n///   b: desc"
+        )
+
+    def test_builder_doc_line_renders_the_function_name(self):
+        result = generate_binding([_esc_function(b"go_now")], "DocContract")
+        assert "/// Build an AssembledTransaction for the go_now method." in result
+
+    def test_doc_line_endings_are_normalized(self):
+        result = generate_binding(
+            [_esc_doc_enum(b"First.\r\nSecond.\rThird.")], "DocContract"
+        )
+        assert "\r" not in result
+        assert "/// First." in result
+        assert "/// Second." in result
+        assert "/// Third." in result
+
+    def test_empty_doc_uses_the_fallback(self):
+        result = generate_binding([_esc_doc_enum(b"")], "DocContract")
+        assert "/// Generated enum DocContractDocEnum" in result
+
+    def test_doc_of_only_newlines_emits_bare_markers(self):
+        assert swift_doc(b"\n\n", "unused") == "///\n///\n///"
+
+    def test_trailing_newline_emits_a_final_bare_marker(self):
+        assert swift_doc(b"text\n", "unused") == "/// text\n///"
+
+    def test_blank_doc_line_keeps_the_marker_without_trailing_space(self):
+        assert swift_doc(b"one\n\ntwo", "unused") == "/// one\n///\n/// two"
+
+    def test_udt_name_is_escaped_in_diagnostic_messages(self):
+        result = generate_binding(_esc_udt_set(b'Va"lue'), "C")
+        assert 'message: "Invalid SCVal type for CVa\\"lue"' in result
+        assert 'message: "Invalid value for CVa\\"lue: \\(value)"' in result
+        assert 'message: "Invalid SCVal type for CEVa\\"lueError"' in result
+        assert 'message: "Invalid value for CEVa\\"lueError: \\(value)"' in result
+        assert 'message: "Invalid SCVal type for CSVa\\"lue"' in result
+        assert 'message: "Invalid SCVal type for CTVa\\"lue"' in result
+        assert 'for CVa"lue"' not in result
+
+    # --- string literals ---
+
+    def test_field_name_is_escaped_on_both_encode_and_decode(self):
+        # The encode site writes the map key and the decode site reads it back;
+        # escaping only one of them yields a client that cannot round-trip.
+        result = generate_binding([_esc_field_struct(_HOSTILE_NAME)], "DocContract")
+        assert 'key: .symbol("say\\"hi")' in result
+        assert 'map["say\\"hi"]' in result
+        assert 'map["say"hi"]' not in result
+
+    def test_missing_field_message_escapes_the_name(self):
+        result = generate_binding([_esc_field_struct(_HOSTILE_NAME)], "DocContract")
+        assert "Missing required field 'say\\\"hi'" in result
+
+    def test_union_case_names_are_escaped_in_every_literal(self):
+        result = generate_binding([_esc_union(b'Va"r')], "DocContract")
+        assert '.symbol("Va\\"r")' in result
+        assert '.symbol("TVa\\"r")' in result
+        assert 'case "Va\\"r":' in result
+        assert 'case "TVa\\"r":' in result
+        assert 'Invalid union value for TVa\\"r' in result
+        assert '.symbol("Va"r")' not in result
+
+    def test_union_case_name_is_escaped_in_the_multi_payload_branch(self):
+        # A tuple case with more than one payload renders its own encode arm
+        # and decode guard.
+        result = generate_binding([_esc_union(b'Va"r', payload_types=2)], "DocContract")
+        assert result.count('.symbol("TVa\\"r")') == 1
+        assert 'Invalid union value for TVa\\"r: expected 3 elements' in result
+        assert '.symbol("TVa"r")' not in result
+        assert 'Invalid union value for TVa"r' not in result
+
+    def test_client_method_name_is_escaped_at_both_call_sites(self):
+        result = generate_binding([_esc_function(b'go"x')], "DocContract")
+        assert result.count('name: "go\\"x",') == 2
+        assert 'name: "go"x",' not in result
+
+    def test_client_method_name_is_escaped_when_the_call_returns_a_value(self):
+        # A returning function renders a different invoke body than a void one.
+        result = generate_binding(
+            [_esc_function(b'go"x', returns_value=True)], "DocContract"
+        )
+        assert result.count('name: "go\\"x",') == 2
+        assert 'name: "go"x",' not in result
+
+    # --- the escaper itself ---
+
+    def test_swift_string_escapes_preserve_the_original_text(self):
+        assert swift_string("back\\slash") == "back\\\\slash"
+        assert swift_string('say"hi') == 'say\\"hi'
+        assert swift_string("line\nbreak") == "line\\nbreak"
+        assert swift_string("line\rbreak") == "line\\rbreak"
+        assert swift_string("tab\there") == "tab\\there"
+
+    def test_swift_string_escapes_the_backslash_first(self):
+        # Escaping the quote first would leave the backslash it introduced
+        # unescaped, and the literal would end early.
+        assert swift_string('a\\"b') == 'a\\\\\\"b'
+
+    def test_swift_string_replaces_control_characters(self):
+        # swiftc rejects an unprintable ASCII character inside a literal.
+        assert swift_string("a\x0bb") == "a\\u{b}b"
+        assert swift_string("a\x7fb") == "a\\u{7f}b"
+
+    def test_swift_string_leaves_ordinary_text_alone(self):
+        assert swift_string("transfer_from") == "transfer_from"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Contract-spec text reached the generated source unescaped, in doc comments and string literals. A multi-line doc alone breaks the generated Dart and Swift, and the embedded Stellar Asset Contract spec has 17 such docs, so every SAC client for those two targets fails to compile today. Same defect class as #26 and #32, fixed for the four remaining generators; details in the commit message.
