### PR TITLE
feat: resolve CAP-85 external executable references when fetching specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Please check the help message for the most up-to-date usage information:
 stellar-contract-bindings --help
 ```
 
+The contract id may name any contract instance: one carrying its own Wasm, a Stellar Asset Contract, or a CAP-85 external executable reference, which is resolved through its owner contract automatically.
+
 ### Examples
 
 #### Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "black>=24.10.0",
     "click>=8.1.7",
     "jinja2>=3.1.4",
-    "stellar-sdk>=15.0.0",
+    "stellar-sdk>=16.0.0",
 ]
 
 [project.scripts]

--- a/stellar_contract_bindings/utils.py
+++ b/stellar_contract_bindings/utils.py
@@ -45,12 +45,17 @@ def get_specs_by_wasm_hash(wasm_hash: bytes, rpc_url: str) -> list[xdr.SCSpecEnt
 
 
 def get_specs_by_contract_id(contract_id: str, rpc_url: str) -> list[xdr.SCSpecEntry]:
-    """Get the wasm hash by contract id.
+    """Get the contract specs by contract id.
 
     :param contract_id: The contract id.
     :param rpc_url: The Soroban RPC URL.
-    :return: The wasm hash.
-    :raises ValueError: If contract not found.
+    :return: The contract specs.
+    :raises ValueError: If the contract is not found, or if a CAP-85 external
+        reference names an owner that is not a contract.
+    :raises ExternalRefNotFoundError: If an external reference's tag entry is
+        missing or archived.
+    :raises ContractWasmRetrievalError: If an external reference's tag entry
+        does not hold a valid wasm hash.
     """
     with SorobanServer(rpc_url) as server:
         key = xdr.LedgerKey(
@@ -77,6 +82,18 @@ def get_specs_by_contract_id(contract_id: str, rpc_url: str) -> list[xdr.SCSpecE
             return get_specs_by_wasm_hash(
                 data.contract_data.val.instance.executable.wasm_hash.hash, rpc_url
             )
+        elif (
+                data.contract_data.val.instance.executable.type
+                == xdr.ContractExecutableType.CONTRACT_EXECUTABLE_EXTERNAL_REF
+        ):
+            # A CAP-85 external reference names its code indirectly: the owner
+            # contract holds a persistent tag entry whose value is the wasm
+            # hash. The resolved value is always a wasm hash, never another
+            # reference, so a single resolution step suffices.
+            wasm_hash = server.get_external_ref_wasm_hash(
+                data.contract_data.val.instance.executable.external_ref
+            )
+            return get_specs_by_wasm_hash(wasm_hash, rpc_url)
         else:
             raise ValueError(
                 f"Unknown executable type, type: {data.contract_data.val.instance.executable.type}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,193 @@
+import pytest
+from stellar_sdk import Address, SorobanServer, xdr
+from stellar_sdk.exceptions import ContractWasmRetrievalError, ExternalRefNotFoundError
+from stellar_sdk.soroban_rpc import GetLedgerEntriesResponse, LedgerEntryResult
+
+from stellar_contract_bindings import utils
+from stellar_contract_bindings.metadata import get_token_sc_spec_entry
+
+CONTRACT_ID = "CDOAW6D7NXAPOCO7TFAWZNJHK62E3IYRGNRVX3VOXNKNVOXCLLPJXQCF"
+OWNER_ID = "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE"
+ACCOUNT_ID = "GD5KKP3LHUDXLDCGKP55NLEOEHMS3Z4BS6IDDZFCYU3BDXUZTBWL7JNF"
+# A sentinel: every request the resolver makes is served by the mock, so no
+# test can reach a real network even if the SDK's internal routing changes.
+RPC_URL = "https://rpc.invalid"
+WASM_HASH = bytes(range(32))
+
+
+def _instance_entry(executable: xdr.ContractExecutable) -> LedgerEntryResult:
+    """A contract instance ledger entry carrying the given executable."""
+    instance = xdr.SCContractInstance(executable=executable, storage=None)
+    data = xdr.LedgerEntryData(
+        xdr.LedgerEntryType.CONTRACT_DATA,
+        contract_data=xdr.ContractDataEntry(
+            ext=xdr.ExtensionPoint(0),
+            contract=Address(CONTRACT_ID).to_xdr_sc_address(),
+            key=xdr.SCVal(xdr.SCValType.SCV_LEDGER_KEY_CONTRACT_INSTANCE),
+            durability=xdr.ContractDataDurability.PERSISTENT,
+            val=xdr.SCVal(xdr.SCValType.SCV_CONTRACT_INSTANCE, instance=instance),
+        ),
+    )
+    return LedgerEntryResult(key="k", xdr=data.to_xdr(), lastModifiedLedgerSeq=1)
+
+
+def _tag_entry(val: xdr.SCVal, tag: bytes = b"v1") -> LedgerEntryResult:
+    """The owner contract's executable tag entry holding the given value."""
+    data = xdr.LedgerEntryData(
+        xdr.LedgerEntryType.CONTRACT_DATA,
+        contract_data=xdr.ContractDataEntry(
+            ext=xdr.ExtensionPoint(0),
+            contract=Address(OWNER_ID).to_xdr_sc_address(),
+            key=xdr.SCVal(
+                xdr.SCValType.SCV_EXECUTABLE_TAG, executable_tag=xdr.SCString(tag)
+            ),
+            durability=xdr.ContractDataDurability.PERSISTENT,
+            val=val,
+        ),
+    )
+    return LedgerEntryResult(key="k", xdr=data.to_xdr(), lastModifiedLedgerSeq=1)
+
+
+def _external_ref(owner: str = OWNER_ID, tag: bytes = b"v1") -> xdr.ContractExecutable:
+    return xdr.ContractExecutable(
+        xdr.ContractExecutableType.CONTRACT_EXECUTABLE_EXTERNAL_REF,
+        external_ref=xdr.ContractExecutableExternalRef(
+            executable_owner=Address(owner).to_xdr_sc_address(),
+            tag=xdr.SCString(tag),
+        ),
+    )
+
+
+def _wasm_hash_val(wasm_hash: bytes = WASM_HASH) -> xdr.SCVal:
+    return xdr.SCVal(xdr.SCValType.SCV_BYTES, bytes=xdr.SCBytes(wasm_hash))
+
+
+def _serve_entries(monkeypatch, responses):
+    """Answer successive get_ledger_entries calls from the given lists.
+
+    Everything the resolver requests, including the SDK's tag lookup, goes
+    through get_ledger_entries, so this one seam intercepts every request.
+    Returns the list of key lists received, for asserting on the requests.
+    """
+    calls = []
+
+    def fake_get_ledger_entries(self, keys):
+        calls.append(keys)
+        return GetLedgerEntriesResponse(
+            entries=responses[len(calls) - 1], latestLedger=1
+        )
+
+    monkeypatch.setattr(SorobanServer, "get_ledger_entries", fake_get_ledger_entries)
+    return calls
+
+
+class TestGetSpecsByContractId:
+    def test_external_ref_resolves_to_wasm_specs(self, monkeypatch):
+        calls = _serve_entries(
+            monkeypatch,
+            [[_instance_entry(_external_ref())], [_tag_entry(_wasm_hash_val())]],
+        )
+        received = []
+
+        def fake_get_specs_by_wasm_hash(wasm_hash, rpc_url):
+            received.append((wasm_hash, rpc_url))
+            return ["spec"]
+
+        # Patched at module level so the code read stays out of the ledger mock.
+        monkeypatch.setattr(
+            utils, "get_specs_by_wasm_hash", fake_get_specs_by_wasm_hash
+        )
+        assert utils.get_specs_by_contract_id(CONTRACT_ID, RPC_URL) == ["spec"]
+        assert received == [(WASM_HASH, RPC_URL)]
+        assert len(calls) == 2
+
+    def test_binary_tag_reaches_the_ledger_key_verbatim(self, monkeypatch):
+        tag = b"\xff\xfe\x00"
+        calls = _serve_entries(
+            monkeypatch,
+            [
+                [_instance_entry(_external_ref(tag=tag))],
+                [_tag_entry(_wasm_hash_val(), tag=tag)],
+            ],
+        )
+        monkeypatch.setattr(
+            utils, "get_specs_by_wasm_hash", lambda wasm_hash, rpc_url: ["spec"]
+        )
+        utils.get_specs_by_contract_id(CONTRACT_ID, RPC_URL)
+        tag_key = calls[1][0].contract_data
+        assert tag_key.key.executable_tag.sc_string == tag
+        assert tag_key.durability == xdr.ContractDataDurability.PERSISTENT
+        assert Address.from_xdr_sc_address(tag_key.contract).address == OWNER_ID
+
+    def test_non_contract_owner_raises_without_a_tag_request(self, monkeypatch):
+        calls = _serve_entries(
+            monkeypatch, [[_instance_entry(_external_ref(owner=ACCOUNT_ID))]]
+        )
+        with pytest.raises(ValueError, match="is not a contract"):
+            utils.get_specs_by_contract_id(CONTRACT_ID, RPC_URL)
+        assert len(calls) == 1
+
+    def test_missing_tag_entry_raises(self, monkeypatch):
+        _serve_entries(monkeypatch, [[_instance_entry(_external_ref())], []])
+        with pytest.raises(ExternalRefNotFoundError):
+            utils.get_specs_by_contract_id(CONTRACT_ID, RPC_URL)
+
+    @pytest.mark.parametrize(
+        "val",
+        [
+            xdr.SCVal(xdr.SCValType.SCV_U32, u32=xdr.Uint32(1)),
+            _wasm_hash_val(b"\x01" * 31),
+            _wasm_hash_val(b"\x00" * 32),
+        ],
+        ids=["wrong-arm", "wrong-length", "all-zero"],
+    )
+    def test_malformed_tag_value_raises(self, monkeypatch, val):
+        _serve_entries(
+            monkeypatch, [[_instance_entry(_external_ref())], [_tag_entry(val)]]
+        )
+        with pytest.raises(ContractWasmRetrievalError) as exc:
+            utils.get_specs_by_contract_id(CONTRACT_ID, RPC_URL)
+        # ExternalRefNotFoundError subclasses ContractWasmRetrievalError, so
+        # the exact class is asserted to keep this case distinct from a
+        # missing entry.
+        assert type(exc.value) is ContractWasmRetrievalError
+
+    def test_wasm_instance_resolves_as_before(self, monkeypatch):
+        executable = xdr.ContractExecutable(
+            xdr.ContractExecutableType.CONTRACT_EXECUTABLE_WASM,
+            wasm_hash=xdr.Hash(WASM_HASH),
+        )
+        calls = _serve_entries(monkeypatch, [[_instance_entry(executable)]])
+        received = []
+
+        def fake_get_specs_by_wasm_hash(wasm_hash, rpc_url):
+            received.append(wasm_hash)
+            return ["spec"]
+
+        monkeypatch.setattr(
+            utils, "get_specs_by_wasm_hash", fake_get_specs_by_wasm_hash
+        )
+        assert utils.get_specs_by_contract_id(CONTRACT_ID, RPC_URL) == ["spec"]
+        assert received == [WASM_HASH]
+        assert len(calls) == 1
+
+    def test_sac_instance_returns_the_embedded_token_spec(self, monkeypatch):
+        executable = xdr.ContractExecutable(
+            xdr.ContractExecutableType.CONTRACT_EXECUTABLE_STELLAR_ASSET
+        )
+        _serve_entries(monkeypatch, [[_instance_entry(executable)]])
+        specs = utils.get_specs_by_contract_id(CONTRACT_ID, RPC_URL)
+        assert [s.to_xdr() for s in specs] == [
+            s.to_xdr() for s in get_token_sc_spec_entry()
+        ]
+
+    def test_contract_not_found_raises(self, monkeypatch):
+        _serve_entries(monkeypatch, [[]])
+        with pytest.raises(ValueError, match="Contract not found"):
+            utils.get_specs_by_contract_id(CONTRACT_ID, RPC_URL)
+
+
+def test_get_specs_by_wasm_hash_raises_when_wasm_not_found(monkeypatch):
+    _serve_entries(monkeypatch, [[]])
+    with pytest.raises(ValueError, match="Wasm not found"):
+        utils.get_specs_by_wasm_hash(WASM_HASH, RPC_URL)

--- a/uv.lock
+++ b/uv.lock
@@ -1699,7 +1699,7 @@ requires-dist = [
     { name = "black", specifier = ">=24.10.0" },
     { name = "click", specifier = ">=8.1.7" },
     { name = "jinja2", specifier = ">=3.1.4" },
-    { name = "stellar-sdk", specifier = ">=15.0.0" },
+    { name = "stellar-sdk", specifier = ">=16.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1713,7 +1713,7 @@ dev = [
 
 [[package]]
 name = "stellar-sdk"
-version = "15.0.0"
+version = "16.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mnemonic" },
@@ -1725,9 +1725,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "xdrlib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/68/936b06d7381e340d76de3529451e4458f7dc47a3364dfad4b63a3c2b8bd1/stellar_sdk-15.0.0.tar.gz", hash = "sha256:c62c5b23e187ce44afa8154892287e5dc136b94048731ca32b4bea4817031b73", size = 420729, upload-time = "2026-07-04T00:32:22.537Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/16/351625905e2690382e1e30d683d4fbb0abdfa6e15dd9b1af3af00f8cd62c/stellar_sdk-16.0.0.tar.gz", hash = "sha256:18c41fca4e3c5fb86ff5479dc0315e7266a8db09f11185ed207a0d09c7ccc5f5", size = 424994, upload-time = "2026-08-28T01:19:29.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/8c/6f63b691ce81aa75b3a003c85549a9f9443423da0085fe280afe6614e980/stellar_sdk-15.0.0-py3-none-any.whl", hash = "sha256:a8495dc99fd0c25484e57ad7cc6bceb0e5d708c2e74e20665b167a5974ad1609", size = 980450, upload-time = "2026-07-04T00:32:20.811Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/00/bd3453ef144de379c7647f9e30675d731dd903013fdbafb57f146bd2089e/stellar_sdk-16.0.0-py3-none-any.whl", hash = "sha256:c478927869acdf65d7f9128dd6f903596a7cf418fc575166b5c40b1d5d9c34bc", size = 987450, upload-time = "2026-08-28T01:19:27.816Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Generating bindings by contract id fails for every contract created from a
CAP-85 external reference: the instance entry cannot even be decoded at the
current stellar-sdk floor. This resolves the reference through
`SorobanServer.get_external_ref_wasm_hash` and continues down the existing
wasm path, with the stellar-sdk floor moving to 16.0.0; details in the commit
message.

The SAC branch keeps serving the embedded token spec, so delegating to
`server.get_contract_spec` is not an option: it raises `SACHasNoWasmError` for
asset contracts. The 16.0.0 floor also brings the SDK's new CAP-71 default
(`use_upgraded_auth=True` in simulation), which generated Python clients pick
up at runtime; fine on protocol 27+ networks.

Validated against a live external-ref contract on testnet, protocol 28
(`CDNUJEDEXTZNHMNZ6EYYWHLR3IUBMKYOYBIZFSW6722RJKYKAWSF2YD3`): all six targets
generate bindings identical to those from a plain instance of the same wasm,
and `test_client.py` passes against the bumped SDK.